### PR TITLE
Replace mapdb dependency with H2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.31.30</version> <!-- or latest, e.g., 2.31.30 -->
+                <version>2.31.73</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -162,21 +162,13 @@
         </dependency>
         
         <dependency>
-  <groupId>software.amazon.awssdk</groupId>
-  <artifactId>bedrockruntime</artifactId>
-  <version>2.31.30</version>
-</dependency>
-        
-
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>bedrockagentruntime</artifactId>
+            <artifactId>bedrockruntime</artifactId>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>iam</artifactId>
-            <scope>test</scope>
+            <artifactId>bedrockagentruntime</artifactId>
         </dependency>
 
         <dependency>
@@ -193,33 +185,38 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>iam</artifactId>
+        </dependency>
             
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20240303</version>
+            <version>20250517</version>
         </dependency>
             
         <dependency>
-            <groupId>org.mapdb</groupId>
-            <artifactId>mapdb</artifactId>
-            <version>3.1.0</version>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>2.9.2</version>
+            <version>2.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers</artifactId>
-            <version>2.9.2</version>
+            <version>2.9.4</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parser-pdf-module</artifactId>
-            <version>2.9.2</version>
+            <version>2.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
@@ -229,18 +226,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.19.1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.16.1</version>
+            <version>2.19.0</version>
         </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>iam</artifactId>
-        </dependency>
-
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
This PR replaces the MapDB dependency with H2.  MapDB hasn't had updates in many years - and seems to lack active development and maintenance.