### PR TITLE
[W-21245099] thread starvation (#67)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-amazon-bedrock-connector</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft Amazon Bedrock Connector - Mule 4</name>
     <description>The MuleSoft Amazon Bedrock connector is designed to provide access to Amazon Bedrock foundational models from mule applications</description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-amazon-bedrock-connector</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft Amazon Bedrock Connector - Mule 4</name>
     <description>The MuleSoft Amazon Bedrock connector is designed to provide access to Amazon Bedrock foundational models from mule applications</description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-amazon-bedrock-connector</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft Amazon Bedrock Connector - Mule 4</name>
     <description>The MuleSoft Amazon Bedrock connector is designed to provide access to Amazon Bedrock foundational models from mule applications</description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-amazon-bedrock-connector</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft Amazon Bedrock Connector - Mule 4</name>
     <description>The MuleSoft Amazon Bedrock connector is designed to provide access to Amazon Bedrock foundational models from mule applications</description>

--- a/src/main/java/com/mulesoft/connectors/bedrock/internal/config/BedrockConfiguration.java
+++ b/src/main/java/com/mulesoft/connectors/bedrock/internal/config/BedrockConfiguration.java
@@ -9,10 +9,18 @@ import com.mulesoft.connectors.bedrock.internal.operation.EmbeddingOperation;
 import com.mulesoft.connectors.bedrock.internal.operation.FoundationalModelOperations;
 import com.mulesoft.connectors.bedrock.internal.operation.ImageOperation;
 import com.mulesoft.connectors.bedrock.internal.operation.SentimentOperations;
+import org.mule.runtime.api.lifecycle.Disposable;
+import org.mule.runtime.api.scheduler.Scheduler;
+import org.mule.runtime.api.scheduler.SchedulerConfig;
+import org.mule.runtime.api.scheduler.SchedulerService;
 import org.mule.runtime.extension.api.annotation.Configuration;
 import org.mule.runtime.extension.api.annotation.Operations;
 import org.mule.runtime.extension.api.annotation.connectivity.ConnectionProviders;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
 
 @Configuration(name = "config")
 @DisplayName("Configuration")
@@ -30,5 +38,48 @@ import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
     AssumeRoleConnectionProvider.class
 })
 
-public class BedrockConfiguration implements ConnectorConfig {
+public class BedrockConfiguration implements ConnectorConfig, Disposable {
+
+  private static final Logger logger = LoggerFactory.getLogger(BedrockConfiguration.class);
+
+  private static final int STREAMING_MAX_POOL_SIZE = 200;
+
+  @Inject
+  SchedulerService schedulerService;
+  @Inject
+  SchedulerConfig schedulerConfig;
+
+  private Scheduler streamingScheduler;
+
+  public SchedulerService getSchedulerService() {
+    return schedulerService;
+  }
+
+  public SchedulerConfig getSchedulerConfig() {
+    return schedulerConfig;
+  }
+
+  /**
+   * Returns a shared, bounded IO scheduler for streaming operations. Lazily initialized on first access; fully synchronized for
+   * thread safety.
+   */
+  public synchronized Scheduler getStreamingScheduler() {
+    if (streamingScheduler == null) {
+      streamingScheduler = schedulerService.ioScheduler(
+                                                        SchedulerConfig.config()
+                                                            .withMaxConcurrentTasks(STREAMING_MAX_POOL_SIZE)
+                                                            .withName("bedrock-streaming"));
+      logger.debug("Created bedrock-streaming IO scheduler with maxConcurrentTasks={}", STREAMING_MAX_POOL_SIZE);
+    }
+    return streamingScheduler;
+  }
+
+  @Override
+  public synchronized void dispose() {
+    if (streamingScheduler != null) {
+      logger.debug("Stopping bedrock-streaming scheduler");
+      streamingScheduler.stop();
+      streamingScheduler = null;
+    }
+  }
 }

--- a/src/main/java/com/mulesoft/connectors/bedrock/internal/service/AgentServiceImpl.java
+++ b/src/main/java/com/mulesoft/connectors/bedrock/internal/service/AgentServiceImpl.java
@@ -13,10 +13,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.ExecutionException;
+import org.mule.runtime.api.scheduler.Scheduler;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.json.JSONArray;
@@ -65,6 +71,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 public class AgentServiceImpl extends BedrockServiceImpl implements AgentService {
 
   private static final Logger logger = LoggerFactory.getLogger(AgentServiceImpl.class);
+
   private static final String AGENT_NAMES = "agentNames";
   private static final String AGENT_ID = "agentId";
   private static final String AGENT_NAME = "agentName";
@@ -99,6 +106,7 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
   private static final String METADATA = "metadata";
   private static final String ERROR_KEY = "error";
   private static final String ERROR_WRITING_EVENT_LOG = "Error writing error event: {}";
+  private static final String END_OF_STREAM_SENTINEL = "__END_OF_STREAM__";
 
   private static final AtomicInteger eventCounter = new AtomicInteger(0);
 
@@ -685,8 +693,12 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
                                            StreamingRetryUtility.RetryConfig retryConfig,
                                            String requestId, String correlationId, String userId,
                                            Integer operationTimeout, TimeUnit operationTimeoutUnit) {
-    PipedOutputStream outputStream = null;
+    long requestStartTime = System.currentTimeMillis();
+    logger
+        .debug("SSE streaming request received - agentId: {}, agentAlias: {}, sessionId: {}, requestId: {}, correlationId: {}, promptLength: {}",
+               agentId, agentAliasId, effectiveSessionId, requestId, correlationId, prompt != null ? prompt.length() : 0);
 
+    PipedOutputStream outputStream = null;
     try {
       // Create piped streams for real-time streaming
       outputStream = new PipedOutputStream();
@@ -696,53 +708,45 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
       AtomicBoolean chunksReceived = new AtomicBoolean(false);
       // Track if session-start has been sent (for consistency - always send before error if not already sent)
       AtomicBoolean sessionStartSent = new AtomicBoolean(false);
+      // Track if client disconnected - used to stop processing new chunks and release thread
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+
+      // Bounded queue prevents unbounded memory growth if the writer thread is slow (e.g. slow client).
+      // 1000 is generous for SSE events; offer() returns false if full, which we log and drop to avoid OOM.
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>(1000);
+
       final PipedOutputStream finalOut = outputStream;
-      // Start the streaming process asynchronously
-      CompletableFuture.runAsync(() -> {
-        try {
-          streamBedrockResponseWithRetry(agentAliasId, agentId, prompt, enableTrace, latencyOptimized, effectiveSessionId,
-                                         excludePreviousThinkingSteps, previousConversationTurnsToInclude,
-                                         knowledgeBaseConfigs,
-                                         finalOut, retryConfig, chunksReceived, sessionStartSent, requestId, correlationId,
-                                         userId,
-                                         operationTimeout, operationTimeoutUnit);
-        } catch (Exception e) {
-          if (e instanceof InterruptedException) {
-            Thread.currentThread().interrupt();
-          }
-          try {
-            // Send session-start event before error if not already sent (for consistency)
-            if (sessionStartSent.compareAndSet(false, true)) {
-              JSONObject startEvent =
-                  createSessionStartJson(agentAliasId, agentId, prompt, effectiveSessionId, Instant.now().toString(),
-                                         requestId, correlationId, userId);
-              String sseStart = formatSSEEvent("session-start", startEvent.toString());
-              finalOut.write(sseStart.getBytes(StandardCharsets.UTF_8));
-              finalOut.flush();
-              logger.info(sseStart);
-            }
 
-            // streamBedrockResponseWithRetry already enhances the error message with retry information
-            // The exception message already contains retry details if retries were attempted
-            // Send error as SSE event (createErrorJson will use the exception's message which is already enhanced)
-            JSONObject errorJson = createErrorJson(e);
-            String errorEvent = formatSSEEvent(ERROR_KEY, errorJson.toString());
-            finalOut.write(errorEvent.getBytes(StandardCharsets.UTF_8));
-            finalOut.flush();
-            logger.error(errorEvent);
-          } catch (IOException ioException) {
-            // Log error but can't do much more
-            logger.error(ERROR_WRITING_EVENT_LOG, ioException.getMessage());
-          }
-        } finally {
-          closeQuietly(finalOut);
-        }
-      });
+      // Use Mule's managed IO scheduler for streaming operations instead of a manual ThreadPoolExecutor.
+      // The IO scheduler is designed for blocking I/O tasks and is lifecycle-managed by the Mule runtime,
+      // ensuring graceful shutdown on undeploy (no daemon thread abrupt termination, no classloader leaks).
+      Scheduler streamingScheduler = getConfig().getStreamingScheduler();
 
+      Future<?> writerFuture = submitToScheduler(
+                                                 () -> runWriterTask(writeQueue, finalOut,
+                                                                     clientDisconnected, agentId,
+                                                                     effectiveSessionId, requestId),
+                                                 streamingScheduler);
+
+      // Start the streaming process asynchronously on the Mule IO scheduler
+      // (NOT on ForkJoinPool.commonPool() which has ~CPU-cores threads and would starve under blocking retries)
+      submitToScheduler(
+                        () -> runProducerTask(agentAliasId, agentId, prompt, enableTrace, latencyOptimized,
+                                              effectiveSessionId,
+                                              excludePreviousThinkingSteps, previousConversationTurnsToInclude,
+                                              knowledgeBaseConfigs,
+                                              finalOut, retryConfig, chunksReceived, sessionStartSent, requestId,
+                                              correlationId, userId,
+                                              operationTimeout, operationTimeoutUnit, writeQueue,
+                                              clientDisconnected,
+                                              requestStartTime, writerFuture),
+                        streamingScheduler);
       return inputStream;
 
     } catch (IOException e) {
       // Return error as immediate SSE event
+      logger.debug("Failed to initialize SSE streaming - agentId: {}, sessionId: {}, requestId: {}, error: {}, elapsedMs: {}",
+                   agentId, effectiveSessionId, requestId, e.getMessage(), System.currentTimeMillis() - requestStartTime);
       String errorEvent = formatSSEEvent(ERROR_KEY, createErrorJson(e).toString());
       logger.error(errorEvent);
       if (outputStream != null) {
@@ -762,7 +766,161 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
   }
 
   /**
-   * Wrapper method that adds retry logic around streamBedrockResponse. Only retries if no chunks have been received yet.
+   * Writer task: drains SSE events from the queue and writes them to the piped output stream. Runs until it receives the
+   * {@link #END_OF_STREAM_SENTINEL}. On client disconnect (IOException), sets the clientDisconnected flag and drains the queue to
+   * unblock producers.
+   */
+  private void runWriterTask(BlockingQueue<String> writeQueue, PipedOutputStream outputStream,
+                             AtomicBoolean clientDisconnected, String agentId, String effectiveSessionId, String requestId) {
+    logger.debug("Writer thread started - agentId: {}, sessionId: {}, requestId: {}", agentId,
+                 effectiveSessionId, requestId);
+    try {
+      while (true) {
+        String event = writeQueue.take();
+        if (END_OF_STREAM_SENTINEL.equals(event)) {
+          break;
+        }
+        outputStream.write(event.getBytes(StandardCharsets.UTF_8));
+        outputStream.flush();
+      }
+      logger.debug("Writer thread completed - agentId: {}, sessionId: {}, requestId: {}", agentId,
+                   effectiveSessionId, requestId);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger.debug("Writer thread interrupted - agentId: {}, sessionId: {}, requestId: {}", agentId, effectiveSessionId,
+                   requestId);
+    } catch (IOException e) {
+      clientDisconnected.set(true);
+      logger
+          .error("Writer thread IOException (client disconnect) - agentId: {}, sessionId: {}, requestId: {}, error: {}",
+                 agentId, effectiveSessionId, requestId, e.getMessage());
+      // Drain remaining queue items to prevent blocking producers
+      int drained = 0;
+      while (writeQueue.poll() != null) {
+        drained++;
+      }
+      if (drained > 0) {
+        logger.warn("Drained {} queued events after IOException - agentId: {}, sessionId: {}, requestId: {}",
+                    drained, agentId, effectiveSessionId, requestId);
+      }
+    } finally {
+      try {
+        outputStream.close();
+      } catch (IOException e) {
+        logger.debug("Could not close output stream: {}", e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Producer task: invokes Bedrock with retry logic, queues SSE events for the writer, and ensures the stream terminates cleanly.
+   * On failure, sends a session-start (if not yet sent) and error event before the end-of-stream sentinel. Always waits for the
+   * writer future to complete before returning.
+   */
+  private void runProducerTask(String agentAliasId, String agentId, String prompt, boolean enableTrace,
+                               boolean latencyOptimized, String effectiveSessionId,
+                               boolean excludePreviousThinkingSteps, Integer previousConversationTurnsToInclude,
+                               java.util.List<BedrockAgentsFilteringParameters.KnowledgeBaseConfig> knowledgeBaseConfigs,
+                               PipedOutputStream outputStream, StreamingRetryUtility.RetryConfig retryConfig,
+                               AtomicBoolean chunksReceived, AtomicBoolean sessionStartSent,
+                               String requestId, String correlationId, String userId,
+                               Integer operationTimeout, TimeUnit operationTimeoutUnit,
+                               BlockingQueue<String> writeQueue, AtomicBoolean clientDisconnected,
+                               long requestStartTime, Future<?> writerFuture) {
+    try {
+      streamBedrockResponseWithRetry(agentAliasId, agentId, prompt, enableTrace, latencyOptimized, effectiveSessionId,
+                                     excludePreviousThinkingSteps, previousConversationTurnsToInclude,
+                                     knowledgeBaseConfigs,
+                                     outputStream, retryConfig, chunksReceived, sessionStartSent, requestId, correlationId,
+                                     userId,
+                                     operationTimeout, operationTimeoutUnit, writeQueue, clientDisconnected);
+      logger.debug("Streaming completed - agentId: {}, sessionId: {}, requestId: {}, elapsedMs: {}",
+                   agentId, effectiveSessionId, requestId, System.currentTimeMillis() - requestStartTime);
+    } catch (ModuleException e) {
+      logger.error("Async streaming operation failed - agentId: {}, sessionId: {}, requestId: {}, error: {}, elapsedMs: {}",
+                   agentId, effectiveSessionId, requestId, e.getMessage(), System.currentTimeMillis() - requestStartTime);
+      try {
+        queueStreamFailureEvents(e, agentAliasId, agentId, prompt, effectiveSessionId, requestId, correlationId, userId,
+                                 sessionStartSent, writeQueue);
+      } catch (IOException ioe) {
+        logger.error("Failed to queue failure events - agentId: {}, sessionId: {}, requestId: {}, error: {}",
+                     agentId, effectiveSessionId, requestId, ioe.getMessage());
+      }
+      if (!forceQueueSentinel(writeQueue, agentId, effectiveSessionId, requestId)) {
+        throw new ModuleException(
+                                  "Failed to queue end-of-stream sentinel - stream will not terminate cleanly. agentId: "
+                                      + agentId
+                                      + ", sessionId: " + effectiveSessionId + ", requestId: " + requestId,
+                                  BedrockErrorType.SERVICE_ERROR);
+      }
+    } finally {
+      awaitWriterCompletion(writerFuture, agentId, effectiveSessionId, requestId);
+    }
+  }
+
+  /**
+   * Queues session-start (if not yet sent) and error SSE events to the write queue on streaming failure. Ensures the client
+   * receives a consistent event sequence even when the Bedrock call fails.
+   */
+  private void queueStreamFailureEvents(Exception e, String agentAliasId, String agentId, String prompt,
+                                        String effectiveSessionId, String requestId, String correlationId, String userId,
+                                        AtomicBoolean sessionStartSent, BlockingQueue<String> writeQueue)
+      throws IOException {
+    if (sessionStartSent.compareAndSet(false, true)) {
+      writeSessionStartEvent(agentAliasId, agentId, prompt, effectiveSessionId, requestId, correlationId, userId,
+                             -1, writeQueue);
+    }
+
+    JSONObject errorJson = createErrorJson(e);
+    String errorEvent = formatSSEEvent(ERROR_KEY, errorJson.toString());
+    if (!writeQueue.offer(errorEvent)) {
+      logger.warn("Queue full, dropping error event - agentId: {}, sessionId: {}, requestId: {}",
+                  agentId, effectiveSessionId, requestId);
+    }
+    logger.error("Streaming error - agentId: {}, sessionId: {}, requestId: {}, error: {}",
+                 agentId, effectiveSessionId, requestId, e.getMessage());
+  }
+
+  /**
+   * Forces the end-of-stream sentinel onto the write queue. If the queue is full, drops one item to make room. The sentinel is
+   * critical — without it the writer thread blocks forever on {@code writeQueue.take()}.
+   *
+   * @return {@code true} if the sentinel was successfully queued, {@code false} if it could not be queued even after draining
+   */
+  private boolean forceQueueSentinel(BlockingQueue<String> writeQueue, String agentId, String effectiveSessionId,
+                                     String requestId) {
+    if (writeQueue.offer(END_OF_STREAM_SENTINEL)) {
+      return true;
+    }
+    writeQueue.poll();
+    if (writeQueue.offer(END_OF_STREAM_SENTINEL)) {
+      return true;
+    }
+    logger.error("Failed to queue end-of-stream sentinel after drain - agentId: {}, sessionId: {}, requestId: {}",
+                 agentId, effectiveSessionId, requestId);
+    return false;
+  }
+
+  /**
+   * Waits for the writer future to complete within 5 seconds. Ensures the writer thread has flushed all data and closed the
+   * output stream before the producer thread exits.
+   */
+  private void awaitWriterCompletion(Future<?> writerFuture, String agentId, String effectiveSessionId,
+                                     String requestId) {
+    try {
+      writerFuture.get(5, TimeUnit.SECONDS);
+    } catch (java.util.concurrent.TimeoutException te) {
+      logger.warn("Writer thread did not complete within 5s - agentId: {}, sessionId: {}, requestId: {}",
+                  agentId, effectiveSessionId, requestId);
+    } catch (Exception writerException) {
+      logger.error("Writer thread failed - agentId: {}, sessionId: {}, requestId: {}, error: {}",
+                   agentId, effectiveSessionId, requestId, writerException.getMessage());
+    }
+  }
+
+  /**
+   * Wrapper method that adds retry logic around streamBedrockResponse. Only retries if no chunks have been received yet. Added
+   * writeQueue and clientDisconnected parameters to pass through to streamBedrockResponse
    */
   private void streamBedrockResponseWithRetry(String agentAliasId, String agentId, String prompt,
                                               boolean enableTrace, boolean latencyOptimized,
@@ -773,20 +931,17 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
                                               AtomicBoolean chunksReceived,
                                               AtomicBoolean sessionStartSent,
                                               String requestId, String correlationId, String userId,
-                                              Integer operationTimeout, TimeUnit operationTimeoutUnit)
-      throws ExecutionException, InterruptedException, IOException {
-
+                                              Integer operationTimeout, TimeUnit operationTimeoutUnit,
+                                              BlockingQueue<String> writeQueue, AtomicBoolean clientDisconnected) {
     StreamingRetryUtility.StreamingOperation operation = () -> {
       streamBedrockResponse(agentAliasId, agentId, prompt, enableTrace, latencyOptimized, effectiveSessionId,
                             excludePreviousThinkingSteps, previousConversationTurnsToInclude,
                             knowledgeBaseConfigs, outputStream, chunksReceived, sessionStartSent, requestId,
-                            correlationId, userId, operationTimeout, operationTimeoutUnit);
+                            correlationId, userId, operationTimeout, operationTimeoutUnit, writeQueue, clientDisconnected);
     };
 
-
-
-    StreamingRetryUtility.RetryResult result = StreamingRetryUtility.executeWithRetry(
-                                                                                      operation, retryConfig, chunksReceived);
+    StreamingRetryUtility.RetryResult result =
+        StreamingRetryUtility.executeWithRetry(operation, retryConfig, chunksReceived, agentId, effectiveSessionId, requestId);
     if (!result.isSuccess()) {
       // Create enhanced error message with retry information
       String errorMessage = StreamingRetryUtility.createRetryErrorMessage(
@@ -798,24 +953,13 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
                                                                           retryConfig.getMaxRetries(),
                                                                           result.isChunksReceived());
 
-      // Re-throw the original exception with enhanced message
-      // If it's an ExecutionException, InterruptedException, or IOException, preserve the type
-      Exception lastException = result.getLastException();
-      if (lastException instanceof ExecutionException) {
-        throw new ExecutionException(errorMessage, lastException.getCause());
-      } else if (lastException instanceof InterruptedException) {
-        InterruptedException ie = new InterruptedException(errorMessage);
-        ie.initCause(lastException);
-        throw ie;
-      } else if (lastException instanceof IOException) {
-        throw new IOException(errorMessage, lastException);
-      } else {
-        // For other exceptions, wrap in ModuleException
-        throw new ModuleException(errorMessage, BedrockErrorType.CLIENT_ERROR, lastException);
-      }
+      throw new ModuleException(errorMessage, BedrockErrorType.CLIENT_ERROR, result.getLastException());
     }
   }
 
+  /**
+   * invokeAgentSSEStream and passed through to avoid race conditions
+   */
   private void streamBedrockResponse(String agentAliasId, String agentId, String prompt,
                                      boolean enableTrace, boolean latencyOptimized, String effectiveSessionId,
                                      boolean excludePreviousThinkingSteps, Integer previousConversationTurnsToInclude,
@@ -823,10 +967,17 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
                                      PipedOutputStream outputStream, AtomicBoolean chunksReceived,
                                      AtomicBoolean sessionStartSent, String requestId,
                                      String correlationId, String userId,
-                                     Integer operationTimeout, TimeUnit operationTimeoutUnit)
+                                     Integer operationTimeout, TimeUnit operationTimeoutUnit,
+                                     BlockingQueue<String> writeQueue, AtomicBoolean clientDisconnected)
       throws ExecutionException, InterruptedException, IOException {
 
     long startTime = System.currentTimeMillis();
+
+    // Track chunk timing and count
+    AtomicInteger chunkCount = new AtomicInteger(0);
+    AtomicLong lastChunkTime = new AtomicLong(startTime);
+    AtomicLong timeToFirstChunk = new AtomicLong(-1);
+
     InvokeAgentRequest request = buildStreamingInvokeAgentRequest(agentAliasId, agentId, prompt, enableTrace,
                                                                   latencyOptimized, effectiveSessionId,
                                                                   excludePreviousThinkingSteps,
@@ -835,19 +986,51 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
 
     InvokeAgentResponseHandler.Visitor visitor = InvokeAgentResponseHandler.Visitor.builder()
         .onChunk(chunk -> handleStreamChunk(agentAliasId, agentId, prompt, effectiveSessionId, requestId, correlationId,
-                                            userId, outputStream, chunksReceived, sessionStartSent, chunk))
+                                            userId, chunksReceived, sessionStartSent, startTime, writeQueue, chunk,
+                                            chunkCount, lastChunkTime, timeToFirstChunk, clientDisconnected))
         .build();
 
     InvokeAgentResponseHandler handler = InvokeAgentResponseHandler.builder()
         .subscriber(visitor)
         .onComplete(() -> handleStreamComplete(effectiveSessionId, agentId, agentAliasId, startTime, requestId,
-                                               correlationId, userId, outputStream))
+                                               correlationId, userId, chunkCount, timeToFirstChunk, chunksReceived, writeQueue,
+                                               clientDisconnected))
         .build();
 
     long effectiveTimeoutMs = (operationTimeout != null && operationTimeout > 0)
         ? toDuration(operationTimeout, operationTimeoutUnit).toMillis()
         : getConnection().getConnectionTimeoutMs();
-    getConnection().invokeAgent(request, handler, effectiveTimeoutMs).get();
+    CompletableFuture<Void> invocationFuture = getConnection().invokeAgent(request, handler, effectiveTimeoutMs);
+
+    // Use whenComplete callback to handle client disconnect instead of polling.
+    // When client disconnects (writer IOException), this cancels the Bedrock invocation.
+    invocationFuture.whenComplete((result, throwable) -> {
+      if (throwable == null && clientDisconnected.get()) {
+        logger.debug("Bedrock invocation completed but client already disconnected - agentId: {}, sessionId: {}, requestId: {}",
+                     agentId, effectiveSessionId, requestId);
+      }
+    });
+
+    try {
+      // Block until Bedrock invocation completes (or fails/times out).
+      // Client disconnect is handled by the writer thread setting clientDisconnected=true,
+      // which causes handleStreamChunk to skip queuing and handleStreamComplete to send sentinel.
+      invocationFuture.get();
+    } catch (ExecutionException | InterruptedException e) {
+      // If client disconnected during invocation, no need to propagate the error
+      if (clientDisconnected.get()) {
+        logger.debug("Client disconnected, suppressing Bedrock error - agentId: {}, sessionId: {}, requestId: {}",
+                     agentId, effectiveSessionId, requestId);
+        if (!forceQueueSentinel(writeQueue, agentId, effectiveSessionId, requestId)) {
+          throw new ModuleException(
+                                    "Failed to queue end-of-stream sentinel after client disconnect. agentId: " + agentId
+                                        + ", sessionId: " + effectiveSessionId + ", requestId: " + requestId,
+                                    BedrockErrorType.SERVICE_ERROR);
+        }
+        return;
+      }
+      throw e;
+    }
   }
 
   private InvokeAgentRequest buildStreamingInvokeAgentRequest(String agentAliasId, String agentId, String prompt,
@@ -876,84 +1059,120 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
   }
 
   private void handleStreamChunk(String agentAliasId, String agentId, String prompt, String effectiveSessionId,
-                                 String requestId, String correlationId, String userId, PipedOutputStream outputStream,
-                                 AtomicBoolean chunksReceived, AtomicBoolean sessionStartSent, PayloadPart chunk) {
+                                 String requestId, String correlationId, String userId,
+                                 AtomicBoolean chunksReceived, AtomicBoolean sessionStartSent, long startTime,
+                                 BlockingQueue<String> writeQueue, PayloadPart chunk,
+                                 AtomicInteger chunkCount, AtomicLong lastChunkTime, AtomicLong timeToFirstChunk,
+                                 AtomicBoolean clientDisconnected) {
+    // IMPORTANT: This callback runs on Netty's event loop thread.
+    // We must NOT block here, so we queue the data for the writer thread.
+    // Skip processing if client already disconnected - prevents queue growth
+    if (clientDisconnected.get()) {
+      return;
+    }
     try {
       chunksReceived.set(true);
+      // Track chunk timing
+      long currentTime = System.currentTimeMillis();
+      int currentChunkCount = chunkCount.incrementAndGet();
+      long timeSinceLastChunk = currentTime - lastChunkTime.getAndSet(currentTime);
+
       if (sessionStartSent.compareAndSet(false, true)) {
+        long firstChunkTime = currentTime - startTime;
+        timeToFirstChunk.set(firstChunkTime);
+        logger.debug("First chunk received - agentId: {}, sessionId: {}, requestId: {}, timeToFirstChunkMs: {}",
+                     agentId, effectiveSessionId, requestId, firstChunkTime);
         writeSessionStartEvent(agentAliasId, agentId, prompt, effectiveSessionId, requestId, correlationId, userId,
-                               outputStream);
+                               firstChunkTime, writeQueue);
+      } else if (timeSinceLastChunk > 1000) {
+        logger.debug("Slow chunk gap - agentId: {}, sessionId: {}, requestId: {}, chunkNumber: {}, gapMs: {}",
+                     agentId, effectiveSessionId, requestId, currentChunkCount, timeSinceLastChunk);
       }
       JSONObject chunkData = createChunkJson(chunk);
       String sseEvent = formatSSEEvent(CHUNK, chunkData.toString());
-      outputStream.write(sseEvent.getBytes(StandardCharsets.UTF_8));
-      outputStream.flush();
-      logger.debug(sseEvent);
+      boolean queued = writeQueue.offer(sseEvent);
+      if (!queued) {
+        logger.warn("Queue full, dropping chunk event - agentId: {}, sessionId: {}, requestId: {}, chunkNumber: {}",
+                    agentId, effectiveSessionId, requestId, currentChunkCount);
+      }
     } catch (IOException e) {
-      writeChunkErrorEvent(e, outputStream);
+      writeChunkErrorEvent(e, writeQueue);
     }
   }
 
   private void writeSessionStartEvent(String agentAliasId, String agentId, String prompt, String effectiveSessionId,
                                       String requestId, String correlationId, String userId,
-                                      PipedOutputStream outputStream)
+                                      long firstChunkTime, BlockingQueue<String> writeQueue)
       throws IOException {
     JSONObject startEvent = createSessionStartJson(agentAliasId, agentId, prompt, effectiveSessionId,
-                                                   Instant.now().toString(), requestId, correlationId, userId);
+                                                   Instant.now().toString(), requestId, correlationId, userId, firstChunkTime);
     String sseStart = formatSSEEvent("session-start", startEvent.toString());
-    outputStream.write(sseStart.getBytes(StandardCharsets.UTF_8));
-    outputStream.flush();
-    logger.info(sseStart);
+    if (!writeQueue.offer(sseStart)) {
+      throw new IOException(
+                            "Failed to queue session-start event - agentId: " + agentId
+                                + ", sessionId: " + effectiveSessionId + ", requestId: " + requestId);
+    }
   }
 
-  private void writeChunkErrorEvent(IOException e, PipedOutputStream outputStream) {
-    try {
-      String errorEvent = formatSSEEvent("chunk-error", createErrorJson(e).toString());
-      outputStream.write(errorEvent.getBytes(StandardCharsets.UTF_8));
-      outputStream.flush();
-      logger.error(errorEvent);
-    } catch (IOException ioException) {
-      logger.error(ERROR_WRITING_EVENT_LOG, ioException.getMessage());
+  private void writeChunkErrorEvent(IOException e, BlockingQueue<String> writeQueue) {
+    String errorEvent = formatSSEEvent("chunk-error", createErrorJson(e).toString());
+    if (!writeQueue.offer(errorEvent)) {
+      logger.warn("Queue full, dropping chunk-error event");
     }
+    logger.error("Error processing chunk: {}", e.getMessage());
   }
 
   private void handleStreamComplete(String effectiveSessionId, String agentId, String agentAliasId, long startTime,
                                     String requestId, String correlationId, String userId,
-                                    PipedOutputStream outputStream) {
+                                    AtomicInteger chunkCount, AtomicLong timeToFirstChunk,
+                                    AtomicBoolean chunksReceived, BlockingQueue<String> writeQueue,
+                                    AtomicBoolean clientDisconnected) {
+    // IMPORTANT: This callback runs on Netty's event loop thread.
+    // We must NOT block here, so we queue the data for the writer thread.
+    // Skip completion event if client already disconnected
+    if (clientDisconnected.get()) {
+      logger.debug("Skipping completion - client disconnected - agentId: {}, sessionId: {}, requestId: {}",
+                   agentId, effectiveSessionId, requestId);
+      forceQueueSentinel(writeQueue, agentId, effectiveSessionId, requestId);
+      return;
+    }
     try {
-      long endTime = System.currentTimeMillis();
-      JSONObject completionData = createCompletionJson(effectiveSessionId, agentId, agentAliasId, endTime - startTime,
-                                                       requestId, correlationId, userId);
+      long totalDuration = System.currentTimeMillis() - startTime;
+      int finalChunkCount = chunkCount.get();
+      long timeToFirstChunkMs = timeToFirstChunk.get();
+
+      JSONObject completionData = createCompletionJson(effectiveSessionId, agentId, agentAliasId, totalDuration,
+                                                       requestId, correlationId, userId,
+                                                       timeToFirstChunkMs >= 0 ? timeToFirstChunkMs : -1, finalChunkCount);
       String completionEvent = formatSSEEvent("session-complete", completionData.toString());
-      outputStream.write(completionEvent.getBytes(StandardCharsets.UTF_8));
-      outputStream.flush();
-      logger.info(completionEvent);
-    } catch (IOException e) {
-      try {
-        String errorEvent = formatSSEEvent("completion-error", createErrorJson(e).toString());
-        outputStream.write(errorEvent.getBytes(StandardCharsets.UTF_8));
-        outputStream.flush();
-        logger.error(errorEvent);
-      } catch (IOException ioException) {
-        logger.error(ERROR_WRITING_EVENT_LOG, ioException.getMessage());
+      if (!writeQueue.offer(completionEvent)) {
+        logger.warn("Queue full, dropping completion event - agentId: {}, sessionId: {}, requestId: {}",
+                    agentId, effectiveSessionId, requestId);
+      }
+    } catch (Exception e) {
+      logger.error("Error creating completion event - agentId: {}, sessionId: {}, requestId: {}, error: {}",
+                   agentId, effectiveSessionId, requestId, e.getMessage());
+      String errorEvent = formatSSEEvent("completion-error", createErrorJson(e).toString());
+      if (!writeQueue.offer(errorEvent)) {
+        logger.warn("Queue full, dropping completion-error event - agentId: {}, sessionId: {}, requestId: {}",
+                    agentId, effectiveSessionId, requestId);
       }
     } finally {
-      try {
-        outputStream.close();
-      } catch (IOException ioException) {
-        logger.error(ERROR_WRITING_EVENT_LOG, ioException.getMessage());
-      }
+      forceQueueSentinel(writeQueue, agentId, effectiveSessionId, requestId);
     }
   }
 
   private static JSONObject createCompletionJson(String sessionId, String agentId, String agentAlias, long duration,
-                                                 String requestId, String correlationId, String userId) {
+                                                 String requestId, String correlationId, String userId, long timeToFirstChunkMs,
+                                                 int totalChunks) {
     JSONObject completionData = new JSONObject();
     completionData.put(SESSION_ID, sessionId);
     completionData.put(AGENT_ID, agentId);
     completionData.put(AGENT_ALIAS, agentAlias);
     completionData.put("status", "completed");
     completionData.put("total_duration_ms", duration);
+    completionData.put("timeToFirstChunkMs", timeToFirstChunkMs);
+    completionData.put("totalChunks", totalChunks);
     completionData.put(TIMESTAMP, Instant.now().toString());
     if (requestId != null && !requestId.isEmpty()) {
       completionData.put("requestId", requestId);
@@ -1000,7 +1219,7 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
 
   private static JSONObject createSessionStartJson(String agentAlias, String agentId, String prompt,
                                                    String sessionId, String timestamp, String requestId, String correlationId,
-                                                   String userId) {
+                                                   String userId, long timeToFirstChunkMs) {
     JSONObject startData = new JSONObject();
     startData.put(SESSION_ID, sessionId);
     startData.put(AGENT_ID, agentId);
@@ -1008,6 +1227,7 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
     startData.put(PROMPT, prompt);
     startData.put(PROCESSED_AT, timestamp);
     startData.put("status", "started");
+    startData.put("timeToFirstChunkMs", timeToFirstChunkMs);
     if (requestId != null && !requestId.isEmpty()) {
       startData.put("requestId", requestId);
     }
@@ -1018,5 +1238,22 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
       startData.put("userId", userId);
     }
     return startData;
+  }
+
+  /**
+   * Submits a task to the Mule IO scheduler via {@link Scheduler#submit(Runnable)}. If the scheduler rejects the task (e.g. all
+   * concurrent slots are occupied), the rejection propagates as a {@link ModuleException} so the caller can return a clean error
+   * to the client. Running on the caller thread is not safe here because the writer and producer tasks have a producer-consumer
+   * dependency that would deadlock if both ran on the same thread.
+   */
+  private static Future<?> submitToScheduler(Runnable task, Scheduler scheduler) {
+    try {
+      return scheduler.submit(task);
+    } catch (RejectedExecutionException e) {
+      throw new ModuleException(
+                                "Streaming scheduler capacity exceeded - all concurrent slots are occupied. "
+                                    + "Consider increasing the scheduler pool size or reducing concurrent streaming requests.",
+                                BedrockErrorType.SERVICE_ERROR, e);
+    }
   }
 }

--- a/src/main/java/com/mulesoft/connectors/bedrock/internal/util/StreamingRetryUtility.java
+++ b/src/main/java/com/mulesoft/connectors/bedrock/internal/util/StreamingRetryUtility.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
 
 /**
  * Utility class for handling retries in streaming operations. Implements exponential backoff and retryable exception detection.
@@ -78,8 +79,10 @@ public class StreamingRetryUtility {
   }
 
   /**
-   * Determines if a throwable is retryable for operations. Only retries on timeout and network-related errors. Handles both
-   * Exception and RuntimeException (including CompletionException).
+   * Determines if a throwable is retryable for operations. Retries on: - Server-side errors (HTTP 5XX) and throttling (HTTP 429)
+   * via SdkServiceException - Timeout and network-related errors via SdkClientException - TimeoutException Handles wrapper
+   * exceptions (CompletionException, ExecutionException, RuntimeException) by unwrapping to the root cause. Does NOT retry on
+   * client errors (HTTP 4XX except 429) such as ValidationException, AccessDeniedException, ResourceNotFoundException.
    *
    * @param throwable The throwable to check
    * @return true if the throwable is retryable, false otherwise
@@ -90,6 +93,9 @@ public class StreamingRetryUtility {
     }
     if (throwable instanceof CompletionException) {
       return isRetryableCompletionException((CompletionException) throwable);
+    }
+    if (throwable instanceof SdkServiceException) {
+      return isRetryableSdkServiceException((SdkServiceException) throwable);
     }
     if (throwable instanceof SdkClientException) {
       return isRetryableSdkClientException((SdkClientException) throwable);
@@ -122,6 +128,9 @@ public class StreamingRetryUtility {
     if (cause instanceof TimeoutException) {
       return true;
     }
+    if (cause instanceof SdkServiceException) {
+      return isRetryableSdkServiceException((SdkServiceException) cause);
+    }
     if (cause instanceof SdkClientException) {
       return isRetryableSdkClientException((SdkClientException) cause);
     }
@@ -136,6 +145,9 @@ public class StreamingRetryUtility {
   private static boolean isRetryableGenericException(Exception exception) {
     if (exception instanceof TimeoutException) {
       return true;
+    }
+    if (exception instanceof SdkServiceException) {
+      return isRetryableSdkServiceException((SdkServiceException) exception);
     }
     if (exception instanceof SdkClientException) {
       return isRetryableSdkClientException((SdkClientException) exception);
@@ -171,6 +183,25 @@ public class StreamingRetryUtility {
         lowerMessage.contains("failed to connect") ||
         lowerMessage.contains("connection refused") ||
         lowerMessage.contains("connection reset");
+  }
+
+  /**
+   * Checks if an SdkServiceException is retryable based on its HTTP status code. Only server-side errors (5XX) and throttling
+   * (429) are retryable. Client errors (4XX except 429) such as ValidationException (400), AccessDeniedException (403), and
+   * ResourceNotFoundException (404) are NOT retryable as they indicate request-level problems that will not resolve on retry.
+   *
+   * @param exception The SdkServiceException to check
+   * @return true if retryable (5XX or 429), false otherwise
+   */
+  private static boolean isRetryableSdkServiceException(SdkServiceException exception) {
+    int statusCode = exception.statusCode();
+    boolean retryable = statusCode >= 500 || statusCode == 429;
+    if (retryable) {
+      logger.debug("SdkServiceException with status {} is retryable: {}", statusCode, exception.getMessage());
+    } else {
+      logger.debug("SdkServiceException with status {} is not retryable (client error): {}", statusCode, exception.getMessage());
+    }
+    return retryable;
   }
 
   /**
@@ -274,7 +305,10 @@ public class StreamingRetryUtility {
   public static RetryResult executeWithRetry(
                                              StreamingOperation operation,
                                              RetryConfig config,
-                                             AtomicBoolean chunksReceived) {
+                                             AtomicBoolean chunksReceived,
+                                             String agentId,
+                                             String sessionId,
+                                             String requestId) {
 
     if (!config.isEnabled()) {
       return executeStreamingOnce(operation, chunksReceived);
@@ -282,26 +316,74 @@ public class StreamingRetryUtility {
 
     Exception lastException = null;
     int attemptsMade = 0;
+    long retryStartTime = System.currentTimeMillis();
+
 
     for (int attempt = 0; attempt <= config.getMaxRetries(); attempt++) {
       attemptsMade++;
+      long attemptStartTime = System.currentTimeMillis();
       try {
         if (attempt > 0) {
           chunksReceived.set(false);
+          logger
+              .debug("Retry attempt {} starting - agentId: {}, sessionId: {}, requestId: {}, attemptNumber: {}, totalAttempts: {}",
+                     attemptsMade, agentId, sessionId, requestId, attempt, config.getMaxRetries() + 1);
+        } else {
+          logger.debug("Initial attempt starting - agentId: {}, sessionId: {}, requestId: {}", agentId, sessionId, requestId);
         }
         operation.execute();
+        // Success - exit retry loop
+        long attemptDuration = System.currentTimeMillis() - attemptStartTime;
+        logger
+            .debug("Operation succeeded on attempt {} - agentId: {}, sessionId: {}, requestId: {}, attemptDurationMs: {}, totalElapsedMs: {}",
+                   attemptsMade, agentId, sessionId, requestId, attemptDuration, System.currentTimeMillis() - retryStartTime);
         return new RetryResult(true, null, attemptsMade, chunksReceived.get());
       } catch (Exception e) {
         lastException = e;
         boolean chunksWereReceived = chunksReceived.get();
-        if (!canRetryStreaming(attempt, config, e, chunksWereReceived)) {
-          return failStreamingRetry(e, attemptsMade, chunksWereReceived, config);
+        long attemptDuration = System.currentTimeMillis() - attemptStartTime;
+        // Check if we can retry
+        boolean canRetry = attempt < config.getMaxRetries()
+            && isRetryableException(e)
+            && !chunksWereReceived; // CRITICAL: Only retry if no chunks received
+        if (!canRetry) {
+          String reason;
+          if (chunksWereReceived) {
+            reason = "chunks were already received";
+          } else if (!isRetryableException(e)) {
+            reason = "exception is not retryable: " + e.getClass().getSimpleName();
+          } else {
+            reason = "max retries (" + config.getMaxRetries() + ") exceeded";
+          }
+          logger
+              .warn("Cannot retry streaming operation (attempt {}): {} - agentId: {}, sessionId: {}, requestId: {}, attemptDurationMs: {}, totalElapsedMs: {}",
+                    attemptsMade, reason, agentId, sessionId, requestId, attemptDuration,
+                    System.currentTimeMillis() - retryStartTime);
+          return new RetryResult(false, e, attemptsMade, chunksWereReceived);
         }
-        RetryResult interrupted = sleepBeforeStreamingRetry(attempt, config, attemptsMade, e.getMessage(),
-                                                            chunksWereReceived);
-        if (interrupted != null) {
-          return interrupted;
+        // Calculate exponential backoff
+        long backoffMs = calculateExponentialBackoff(attempt, config.getBaseBackoffMs());
+        logger
+            .warn("Retryable error on attempt {}: {}. Retrying in {}ms - agentId: {}, sessionId: {}, requestId: {}, attemptDurationMs: {}",
+                  attemptsMade, e.getMessage(), backoffMs, agentId, sessionId, requestId, attemptDuration);
+        logger.debug("Waiting {}ms before retry attempt {} - agentId: {}, sessionId: {}, requestId: {}",
+                     backoffMs, attemptsMade + 1, agentId, sessionId, requestId);
+
+        // Wait before retrying
+        try {
+          Thread.sleep(backoffMs);
+          logger.debug("Backoff completed, starting retry attempt {} - agentId: {}, sessionId: {}, requestId: {}",
+                       attemptsMade + 1, agentId, sessionId, requestId);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          logger.debug("Retry interrupted during backoff - agentId: {}, sessionId: {}, requestId: {}, attempt: {}",
+                       agentId, sessionId, requestId, attemptsMade);
+          return new RetryResult(false,
+                                 new Exception("Retry interrupted", ie),
+                                 attemptsMade,
+                                 chunksWereReceived);
         }
+
       }
     }
 
@@ -314,41 +396,6 @@ public class StreamingRetryUtility {
       return new RetryResult(true, null, 1, chunksReceived.get());
     } catch (Exception e) {
       return new RetryResult(false, e, 1, chunksReceived.get());
-    }
-  }
-
-  private static boolean canRetryStreaming(int attempt, RetryConfig config, Exception e, boolean chunksWereReceived) {
-    return attempt < config.getMaxRetries() && isRetryableException(e) && !chunksWereReceived;
-  }
-
-  private static RetryResult failStreamingRetry(Exception e, int attemptsMade, boolean chunksWereReceived,
-                                                RetryConfig config) {
-    String reason = buildStreamingCannotRetryReason(e, chunksWereReceived, config);
-    logger.warn("Cannot retry streaming operation (attempt {}): {}", attemptsMade, reason);
-    return new RetryResult(false, e, attemptsMade, chunksWereReceived);
-  }
-
-  private static String buildStreamingCannotRetryReason(Exception e, boolean chunksWereReceived, RetryConfig config) {
-    if (chunksWereReceived) {
-      return "chunks were already received";
-    }
-    if (!isRetryableException(e)) {
-      return "exception is not retryable: " + e.getClass().getSimpleName();
-    }
-    return "max retries (" + config.getMaxRetries() + ") exceeded";
-  }
-
-  /** Returns non-null RetryResult if interrupted, null to continue retrying. */
-  private static RetryResult sleepBeforeStreamingRetry(int attempt, RetryConfig config, int attemptsMade,
-                                                       String lastMessage, boolean chunksWereReceived) {
-    long backoffMs = calculateExponentialBackoff(attempt, config.getBaseBackoffMs());
-    logger.warn("Retryable error on attempt {}: {}. Retrying in {}ms", attemptsMade, lastMessage, backoffMs);
-    try {
-      Thread.sleep(backoffMs);
-      return null;
-    } catch (InterruptedException ie) {
-      Thread.currentThread().interrupt();
-      return new RetryResult(false, new Exception("Retry interrupted", ie), attemptsMade, chunksWereReceived);
     }
   }
 

--- a/src/test/java/com/mulesoft/connectors/bedrock/internal/config/BedrockConfigurationTest.java
+++ b/src/test/java/com/mulesoft/connectors/bedrock/internal/config/BedrockConfigurationTest.java
@@ -1,0 +1,128 @@
+package com.mulesoft.connectors.bedrock.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mule.runtime.api.scheduler.Scheduler;
+import org.mule.runtime.api.scheduler.SchedulerConfig;
+import org.mule.runtime.api.scheduler.SchedulerService;
+
+import java.lang.reflect.Field;
+
+@DisplayName("BedrockConfiguration")
+class BedrockConfigurationTest {
+
+  private BedrockConfiguration config;
+  private SchedulerService mockSchedulerService;
+  private Scheduler mockScheduler;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    config = new BedrockConfiguration();
+    mockSchedulerService = mock(SchedulerService.class);
+    mockScheduler = mock(Scheduler.class);
+
+    when(mockSchedulerService.ioScheduler(any(SchedulerConfig.class))).thenReturn(mockScheduler);
+
+    // Inject the mock SchedulerService via reflection (normally @Inject handles this)
+    Field schedulerServiceField = BedrockConfiguration.class.getDeclaredField("schedulerService");
+    schedulerServiceField.setAccessible(true);
+    schedulerServiceField.set(config, mockSchedulerService);
+  }
+
+  @Nested
+  @DisplayName("getStreamingScheduler")
+  class GetStreamingScheduler {
+
+    @Test
+    @DisplayName("lazily creates IO scheduler on first access")
+    void createsSchedulerOnFirstAccess() {
+      Scheduler result = config.getStreamingScheduler();
+
+      assertThat(result).isSameAs(mockScheduler);
+      verify(mockSchedulerService).ioScheduler(any(SchedulerConfig.class));
+    }
+
+    @Test
+    @DisplayName("returns same instance on subsequent calls (singleton)")
+    void returnsSameInstanceOnSubsequentCalls() {
+      Scheduler first = config.getStreamingScheduler();
+      Scheduler second = config.getStreamingScheduler();
+
+      assertThat(first).isSameAs(second);
+      // ioScheduler should only be called once despite two getStreamingScheduler calls
+      verify(mockSchedulerService).ioScheduler(any(SchedulerConfig.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("dispose")
+  class Dispose {
+
+    @Test
+    @DisplayName("stops scheduler when it was created")
+    void stopsSchedulerWhenCreated() {
+      config.getStreamingScheduler(); // trigger creation
+      config.dispose();
+
+      verify(mockScheduler).stop();
+    }
+
+    @Test
+    @DisplayName("does nothing when scheduler was never created")
+    void doesNothingWhenNeverCreated() {
+      config.dispose(); // should not throw
+
+      verify(mockScheduler, never()).stop();
+    }
+
+    @Test
+    @DisplayName("nulls out scheduler so next access creates a new one")
+    void nullsOutSchedulerAfterDispose() {
+      config.getStreamingScheduler();
+      config.dispose();
+
+      // A second call to getStreamingScheduler should create a new scheduler
+      Scheduler newScheduler = mock(Scheduler.class);
+      when(mockSchedulerService.ioScheduler(any(SchedulerConfig.class))).thenReturn(newScheduler);
+
+      Scheduler result = config.getStreamingScheduler();
+      assertThat(result).isSameAs(newScheduler);
+    }
+  }
+
+  @Nested
+  @DisplayName("getSchedulerService")
+  class GetSchedulerService {
+
+    @Test
+    @DisplayName("returns injected SchedulerService")
+    void returnsInjectedSchedulerService() {
+      assertThat(config.getSchedulerService()).isSameAs(mockSchedulerService);
+    }
+  }
+
+  @Nested
+  @DisplayName("getSchedulerConfig")
+  class GetSchedulerConfigTest {
+
+    @Test
+    @DisplayName("returns injected SchedulerConfig")
+    void returnsInjectedSchedulerConfig() throws Exception {
+      SchedulerConfig mockConfig = mock(SchedulerConfig.class);
+      Field schedulerConfigField = BedrockConfiguration.class.getDeclaredField("schedulerConfig");
+      schedulerConfigField.setAccessible(true);
+      schedulerConfigField.set(config, mockConfig);
+
+      assertThat(config.getSchedulerConfig()).isSameAs(mockConfig);
+    }
+  }
+}

--- a/src/test/java/com/mulesoft/connectors/bedrock/internal/service/AgentServiceImplTest.java
+++ b/src/test/java/com/mulesoft/connectors/bedrock/internal/service/AgentServiceImplTest.java
@@ -2,2273 +2,1170 @@ package com.mulesoft.connectors.bedrock.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyLong;
 
-import java.io.InputStream;
-import java.util.Collections;
+import java.io.IOException;
+import java.io.PipedOutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
-import com.mulesoft.connectors.bedrock.api.parameter.BedrockAgentsResponseLoggingParameters;
-import software.amazon.awssdk.core.document.Document;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import com.mulesoft.connectors.bedrock.api.parameter.BedrockAgentsFilteringParameters;
 import com.mulesoft.connectors.bedrock.api.parameter.BedrockAgentsMultipleFilteringParameters;
-import org.mule.runtime.extension.api.exception.ModuleException;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import java.util.concurrent.TimeUnit;
-import com.mulesoft.connectors.bedrock.api.parameter.BedrockAgentsResponseParameters;
-import com.mulesoft.connectors.bedrock.api.parameter.BedrockAgentsSessionParameters;
-import com.mulesoft.connectors.bedrock.internal.parameter.BedrockParameters;
 import com.mulesoft.connectors.bedrock.internal.config.BedrockConfiguration;
 import com.mulesoft.connectors.bedrock.internal.connection.BedrockConnection;
 import com.mulesoft.connectors.bedrock.internal.support.IntegrationTestParamHelper;
+import com.mulesoft.connectors.bedrock.internal.util.StreamingRetryUtility;
+import org.mule.runtime.extension.api.exception.ModuleException;
+
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.bedrockagent.model.Agent;
-import software.amazon.awssdk.services.bedrockagent.model.AgentStatus;
-import software.amazon.awssdk.services.bedrockagent.model.AgentSummary;
-import software.amazon.awssdk.services.bedrockagent.model.GetAgentResponse;
-import software.amazon.awssdk.services.bedrockagent.model.ListAgentsResponse;
-import software.amazon.awssdk.services.bedrockagentruntime.model.Attribution;
-import software.amazon.awssdk.services.bedrockagentruntime.model.Citation;
-import software.amazon.awssdk.services.bedrockagentruntime.model.GeneratedResponsePart;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.bedrockagentruntime.model.InvokeAgentRequest;
 import software.amazon.awssdk.services.bedrockagentruntime.model.InvokeAgentResponseHandler;
 import software.amazon.awssdk.services.bedrockagentruntime.model.PayloadPart;
-import software.amazon.awssdk.services.bedrockagentruntime.model.RetrievalResultContent;
-import software.amazon.awssdk.services.bedrockagentruntime.model.RetrievalResultLocation;
 import software.amazon.awssdk.services.bedrockagentruntime.model.RetrievedReference;
-import software.amazon.awssdk.services.bedrockagentruntime.model.TextResponsePart;
-import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
-import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 
+/**
+ * Unit tests for AgentServiceImpl async streaming error paths, writer thread edge cases, and private helper methods that are
+ * difficult to exercise via MUnit integration tests.
+ */
 @DisplayName("AgentServiceImpl")
 class AgentServiceImplTest {
 
-  @Test
-  @DisplayName("can be constructed with config and connection")
-  void constructor() {
+  private AgentServiceImpl service;
+  private BedrockConnection mockConnection;
+
+  @BeforeEach
+  void setUp() {
     BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    assertThat(service).isNotNull();
+    mockConnection = mock(BedrockConnection.class);
+    when(mockConnection.getConnectionTimeoutMs()).thenReturn(30000);
+    when(mockConnection.getRegion()).thenReturn("us-east-1");
+    service = new AgentServiceImpl(config, mockConnection);
   }
 
-  @Test
-  @DisplayName("implements AgentService and extends BedrockServiceImpl")
-  void typeHierarchy() {
-    AgentServiceImpl service = new AgentServiceImpl(mock(BedrockConfiguration.class), mock(BedrockConnection.class));
-    assertThat(service).isInstanceOf(AgentService.class);
-    assertThat(service).isInstanceOf(BedrockServiceImpl.class);
-  }
+  // ==================== handleStreamChunk ====================
 
-  @Test
-  @DisplayName("listAgents returns JSON with agentNames when connection returns response")
-  void listAgentsReturnsJson() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentSummary summary = AgentSummary.builder().agentName("TestAgent").agentId("AGENT1").build();
-    when(connection.listAgents(any()))
-        .thenReturn(ListAgentsResponse.builder().agentSummaries(summary).build());
+  @Nested
+  @DisplayName("handleStreamChunk")
+  class HandleStreamChunk {
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.listAgents();
+    @Test
+    @DisplayName("skips processing when client is disconnected (L1147-1149)")
+    void clientDisconnected_skipsProcessing() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>();
+      AtomicBoolean clientDisconnected = new AtomicBoolean(true);
+      AtomicBoolean chunksReceived = new AtomicBoolean(false);
+      AtomicBoolean sessionStartSent = new AtomicBoolean(false);
+      AtomicInteger chunkCount = new AtomicInteger(0);
+      AtomicLong lastChunkTime = new AtomicLong(System.currentTimeMillis());
+      AtomicLong timeToFirstChunk = new AtomicLong(-1);
 
-    assertThat(result).isNotBlank();
-    assertThat(result).contains("agentNames");
-    assertThat(result).contains("TestAgent");
-  }
+      PayloadPart chunk = PayloadPart.builder()
+          .bytes(SdkBytes.fromUtf8String("test chunk"))
+          .build();
 
-  @Test
-  @DisplayName("listAgents returns JSON with empty array when no agents")
-  void listAgentsReturnsEmptyArray() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.listAgents(any())).thenReturn(ListAgentsResponse.builder().build());
+      invokeHandleStreamChunk(
+                              "alias", "agentId", "prompt", "session1", "req1", "corr1", "user1",
+                              chunksReceived, sessionStartSent, System.currentTimeMillis(),
+                              writeQueue, chunk, chunkCount, lastChunkTime, timeToFirstChunk, clientDisconnected);
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.listAgents();
+      assertThat(writeQueue).isEmpty();
+      assertThat(chunksReceived.get()).isFalse();
+      assertThat(chunkCount.get()).isEqualTo(0);
+    }
 
-    assertThat(result).contains("agentNames");
-    assertThat(result).contains("[]");
-  }
+    @Test
+    @DisplayName("processes chunk and queues SSE event for normal flow")
+    void normalChunk_queuesEvent() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>();
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+      AtomicBoolean chunksReceived = new AtomicBoolean(false);
+      AtomicBoolean sessionStartSent = new AtomicBoolean(false);
+      AtomicInteger chunkCount = new AtomicInteger(0);
+      AtomicLong lastChunkTime = new AtomicLong(System.currentTimeMillis());
+      AtomicLong timeToFirstChunk = new AtomicLong(-1);
 
-  @Test
-  @DisplayName("listAgents throws when connection throws")
-  void listAgentsThrowsWhenConnectionThrows() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.listAgents(any()))
-        .thenThrow(software.amazon.awssdk.core.exception.SdkClientException.builder().message("timeout").build());
+      PayloadPart chunk = PayloadPart.builder()
+          .bytes(SdkBytes.fromUtf8String("Hello world"))
+          .build();
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    org.assertj.core.api.Assertions.assertThatThrownBy(service::listAgents)
-        .isInstanceOf(software.amazon.awssdk.core.exception.SdkClientException.class);
-  }
+      invokeHandleStreamChunk(
+                              "alias", "agentId", "prompt", "session1", "req1", "corr1", "user1",
+                              chunksReceived, sessionStartSent, System.currentTimeMillis(),
+                              writeQueue, chunk, chunkCount, lastChunkTime, timeToFirstChunk, clientDisconnected);
 
-  @Test
-  @DisplayName("getAgentById returns JSON with agent details when connection returns response")
-  void getAgentByIdReturnsJson() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    Agent agent = Agent.builder()
-        .agentId("AGENT1")
-        .agentName("TestAgent")
-        .agentArn("arn:aws:bedrock:us-east-1:123:agent/AGENT1")
-        .agentStatus(AgentStatus.PREPARED)
-        .build();
-    when(connection.getAgent(any())).thenReturn(GetAgentResponse.builder().agent(agent).build());
+      assertThat(chunksReceived.get()).isTrue();
+      assertThat(sessionStartSent.get()).isTrue();
+      assertThat(chunkCount.get()).isEqualTo(1);
+      // Queue should contain session-start + chunk events
+      assertThat(writeQueue.size()).isGreaterThanOrEqualTo(2);
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.getAgentById("AGENT1");
+      String allEvents = drainQueue(writeQueue);
+      assertThat(allEvents).contains("session-start");
+      assertThat(allEvents).contains("chunk");
+      assertThat(allEvents).contains("Hello world");
+    }
 
-    assertThat(result).isNotBlank();
-    assertThat(result).contains("AGENT1");
-    assertThat(result).contains("TestAgent");
-  }
+    @Test
+    @DisplayName("logs slow chunk timing when timeSinceLastChunk > 1s (L1177-1178)")
+    void slowChunkTiming_logs() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>();
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+      AtomicBoolean chunksReceived = new AtomicBoolean(true); // Already received first chunk
+      AtomicBoolean sessionStartSent = new AtomicBoolean(true);
+      AtomicInteger chunkCount = new AtomicInteger(1);
+      // Set lastChunkTime to 2 seconds ago to trigger timeSinceLastChunk > 1000
+      AtomicLong lastChunkTime = new AtomicLong(System.currentTimeMillis() - 2000);
+      AtomicLong timeToFirstChunk = new AtomicLong(100);
 
-  @Test
-  @DisplayName("getAgentById throws when connection throws")
-  void getAgentByIdThrowsWhenConnectionThrows() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getAgent(any()))
-        .thenThrow(software.amazon.awssdk.core.exception.SdkClientException.builder().message("not found").build());
+      PayloadPart chunk = PayloadPart.builder()
+          .bytes(SdkBytes.fromUtf8String("delayed chunk"))
+          .build();
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.getAgentById("agent-1"))
-        .isInstanceOf(software.amazon.awssdk.core.exception.SdkClientException.class);
-  }
+      invokeHandleStreamChunk(
+                              "alias", "agentId", "prompt", "session1", "req1", "corr1", "user1",
+                              chunksReceived, sessionStartSent, System.currentTimeMillis() - 5000,
+                              writeQueue, chunk, chunkCount, lastChunkTime, timeToFirstChunk, clientDisconnected);
 
-  @Test
-  @DisplayName("getAgentById returns full JSON when agent has all fields")
-  void getAgentByIdReturnsFullJson() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    Agent agent = Agent.builder()
-        .agentId("AGENT1")
-        .agentName("TestAgent")
-        .agentArn("arn:aws:bedrock:us-east-1:123:agent/AGENT1")
-        .agentStatus(AgentStatus.PREPARED)
-        .agentResourceRoleArn("roleArn")
-        .clientToken("token")
-        .description("desc")
-        .foundationModel("amazon.nova-lite-v1")
-        .idleSessionTTLInSeconds(600)
-        .instruction("instruction")
-        .build();
-    when(connection.getAgent(any())).thenReturn(GetAgentResponse.builder().agent(agent).build());
+      assertThat(chunkCount.get()).isEqualTo(2);
+      String allEvents = drainQueue(writeQueue);
+      assertThat(allEvents).contains("delayed chunk");
+    }
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.getAgentById("AGENT1");
-
-    assertThat(result).contains("AGENT1");
-    assertThat(result).contains("roleArn");
-    assertThat(result).contains("desc");
-  }
-
-  @Test
-  @DisplayName("definePromptTemplate returns formatted response when connection succeeds")
-  void definePromptTemplateSuccess() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getRegion()).thenReturn("us-east-1");
-    when(connection.answerPrompt(any(InvokeModelRequest.class)))
-        .thenReturn(InvokeModelResponse.builder()
-            .body(software.amazon.awssdk.core.SdkBytes.fromUtf8String("{\"completion\":\"Hello\"}"))
-            .build());
-
-    BedrockParameters params = IntegrationTestParamHelper.bedrockParams("amazon.nova-lite-v1:0", 0.5f, 50);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.definePromptTemplate("Hello {{instructions}}", "instr", "data", params);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("definePromptTemplate throws when connection throws SdkClientException")
-  void definePromptTemplateThrowsOnClientError() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getRegion()).thenReturn("us-east-1");
-    when(connection.answerPrompt(any(InvokeModelRequest.class)))
-        .thenThrow(software.amazon.awssdk.core.exception.SdkClientException.builder().message("network").build());
-
-    BedrockParameters params = IntegrationTestParamHelper.bedrockParams("amazon.nova-lite-v1:0", 0.5f, 50);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    org.assertj.core.api.Assertions.assertThatThrownBy(
-                                                       () -> service.definePromptTemplate("Hi", "instr", "data", params))
-        .isInstanceOf(ModuleException.class);
-  }
-
-  @Test
-  @DisplayName("chatWithAgent returns JSON when invokeAgent completes with no chunks")
-  void chatWithAgentReturnsWhenInvokeCompletes() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("sess-1", false, 2);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 3, 1000L);
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hello", false, false,
-                                          sessionParams,
-                                          null,
-                                          null,
-                                          responseParams,
-                                          null);
-
-    assertThat(result).isNotBlank();
-    assertThat(result).contains("sessionId");
-    assertThat(result).contains("agentId");
-    assertThat(result).contains("chunks");
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with empty sessionId uses UUID")
-  void chatWithAgentEmptySessionId() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("", false, null);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(10, TimeUnit.MINUTES, false, 1, 2000L);
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "aid", "alias", "Hi", false, false,
-                                          sessionParams,
-                                          null,
-                                          null,
-                                          responseParams,
-                                          null);
-
-    assertThat(result).contains("sessionId");
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with requestTimeoutUnit null uses default duration")
-  void chatWithAgentTimeoutUnitNull() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
-    IntegrationTestParamHelper.setField(responseParams, "requestTimeoutUnit", null);
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, null, responseParams, null);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with requestTimeout in milliseconds")
-  void chatWithAgentTimeoutMilliseconds() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", true, 3);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(5000, TimeUnit.MILLISECONDS, true, 2, 500L);
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Prompt", true, true,
-                                          sessionParams,
-                                          null,
-                                          null,
-                                          responseParams,
-                                          null);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with legacy single KB filtering uses buildKnowledgeBaseConfigs")
-  void chatWithAgentLegacySingleKb() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 3, 1000L);
-
-    BedrockAgentsFilteringParameters filteringParams = new BedrockAgentsFilteringParameters();
-    IntegrationTestParamHelper.setField(filteringParams, "knowledgeBaseId", "kb-123");
-    IntegrationTestParamHelper.setField(filteringParams, "numberOfResults", 5);
-    IntegrationTestParamHelper.setField(filteringParams, "overrideSearchType",
-                                        BedrockAgentsFilteringParameters.SearchType.SEMANTIC);
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hello", false, false,
-                                          sessionParams,
-                                          filteringParams,
-                                          null,
-                                          responseParams,
-                                          null);
-
-    assertThat(result).isNotBlank();
-    assertThat(result).contains("chunks");
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with multiple KB params uses multiple path")
-  void chatWithAgentMultipleKb() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", true, 2);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(60, TimeUnit.SECONDS, false, 2, 500L);
-
-    BedrockAgentsFilteringParameters.KnowledgeBaseConfig kbConfig =
-        new BedrockAgentsFilteringParameters.KnowledgeBaseConfig("kb-1", 10,
-                                                                 BedrockAgentsFilteringParameters.SearchType.HYBRID, null, null);
-    BedrockAgentsMultipleFilteringParameters multipleParams = new BedrockAgentsMultipleFilteringParameters();
-    IntegrationTestParamHelper.setField(multipleParams, "knowledgeBases", Collections.singletonList(kbConfig));
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, true,
-                                          sessionParams,
-                                          null,
-                                          multipleParams,
-                                          responseParams,
-                                          null);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("chatWithAgent returns JSON when handler may deliver chunk")
-  void chatWithAgentWithChunkDeliveryAttempt() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenAnswer(invocation -> {
-      InvokeAgentResponseHandler handler = invocation.getArgument(1);
-      CompletableFuture<Void> future = new CompletableFuture<>();
-      try {
-        Object subscriber = getHandlerSubscriber(handler);
-        if (subscriber != null) {
-          PayloadPart chunk = PayloadPart.builder().bytes(SdkBytes.fromUtf8String("Hello chunk")).build();
-          InvokeAgentResponseHandler.Visitor.class.getMethod("onChunk", PayloadPart.class)
-              .invoke(subscriber, chunk);
-        }
-        future.complete(null);
-      } catch (Exception e) {
-        future.completeExceptionally(e);
+    @Test
+    @DisplayName("handles queue size > 25 without error (L1188-1190)")
+    void queueOverflow_logsAndContinues() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>();
+      // Pre-fill queue with 26 items to trigger queueSize > 25 logging
+      for (int i = 0; i < 26; i++) {
+        writeQueue.offer("event-" + i);
       }
-      return future;
-    });
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+      AtomicBoolean chunksReceived = new AtomicBoolean(true);
+      AtomicBoolean sessionStartSent = new AtomicBoolean(true);
+      AtomicInteger chunkCount = new AtomicInteger(5);
+      AtomicLong lastChunkTime = new AtomicLong(System.currentTimeMillis());
+      AtomicLong timeToFirstChunk = new AtomicLong(100);
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("sess-1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 3, 1000L);
+      PayloadPart chunk = PayloadPart.builder()
+          .bytes(SdkBytes.fromUtf8String("overflow chunk"))
+          .build();
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, null, responseParams, null);
+      invokeHandleStreamChunk(
+                              "alias", "agentId", "prompt", "session1", "req1", "corr1", "user1",
+                              chunksReceived, sessionStartSent, System.currentTimeMillis(),
+                              writeQueue, chunk, chunkCount, lastChunkTime, timeToFirstChunk, clientDisconnected);
 
-    assertThat(result).isNotBlank();
-    assertThat(result).contains("fullResponse");
-    assertThat(result).contains("sessionId");
-    assertThat(result).contains("chunks");
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with chunk containing attribution and citations")
-  void chatWithAgentWithChunkWithAttributionAndCitations() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenAnswer(invocation -> {
-      InvokeAgentResponseHandler handler = invocation.getArgument(1);
-      CompletableFuture<Void> future = new CompletableFuture<>();
-      try {
-        Object subscriber = getHandlerSubscriber(handler);
-        if (subscriber != null) {
-          TextResponsePart textPart = TextResponsePart.builder().text("generated").build();
-          GeneratedResponsePart genPart = GeneratedResponsePart.builder().textResponsePart(textPart).build();
-          RetrievalResultContent content = RetrievalResultContent.builder().text("cited text").build();
-          RetrievalResultLocation location = RetrievalResultLocation.builder().type("S3").build();
-          RetrievedReference ref = RetrievedReference.builder()
-              .content(content)
-              .location(location)
-              .metadata(Collections.singletonMap("k", Document.fromString("v")))
-              .build();
-          Citation citation = Citation.builder()
-              .generatedResponsePart(genPart)
-              .retrievedReferences(Collections.singletonList(ref))
-              .build();
-          Attribution attribution = Attribution.builder().citations(Collections.singletonList(citation)).build();
-          PayloadPart chunk = PayloadPart.builder()
-              .bytes(SdkBytes.fromUtf8String("chunk with citation"))
-              .attribution(attribution)
-              .build();
-          InvokeAgentResponseHandler.Visitor.class.getMethod("onChunk", PayloadPart.class).invoke(subscriber, chunk);
-        }
-        future.complete(null);
-      } catch (Exception e) {
-        future.completeExceptionally(e);
-      }
-      return future;
-    });
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("sess-1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 3, 1000L);
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, null, responseParams, null);
-
-    assertThat(result).isNotBlank();
-    // If subscriber was found, chunk with attribution was delivered and result contains citations
-    if (result.contains("citations")) {
-      assertThat(result).contains("retrievedReferences");
+      // Chunk should still be queued despite queue size > 25
+      assertThat(writeQueue.size()).isGreaterThan(26);
+      assertThat(chunkCount.get()).isEqualTo(6);
     }
   }
 
-  private static Object getHandlerSubscriber(InvokeAgentResponseHandler handler) {
-    try {
-      for (java.lang.reflect.Field f : handler.getClass().getDeclaredFields()) {
-        f.setAccessible(true);
-        Object val = f.get(handler);
-        if (val != null && InvokeAgentResponseHandler.Visitor.class.isAssignableFrom(val.getClass())) {
-          return val;
-        }
+  // ==================== handleStreamComplete ====================
+
+  @Nested
+  @DisplayName("handleStreamComplete")
+  class HandleStreamComplete {
+
+    @Test
+    @DisplayName("skips completion and queues sentinel when client disconnected (L1231-1235)")
+    void clientDisconnected_queuesSentinelOnly() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>();
+      AtomicBoolean clientDisconnected = new AtomicBoolean(true);
+      AtomicBoolean chunksReceived = new AtomicBoolean(true);
+      AtomicInteger chunkCount = new AtomicInteger(5);
+      AtomicLong timeToFirstChunk = new AtomicLong(200);
+
+      invokeHandleStreamComplete(
+                                 "session1", "agentId", "alias", System.currentTimeMillis() - 1000,
+                                 "req1", "corr1", "user1",
+                                 chunkCount, timeToFirstChunk, chunksReceived, writeQueue, clientDisconnected);
+
+      assertThat(writeQueue.size()).isEqualTo(1);
+      assertThat(writeQueue.poll()).isEqualTo("__END_OF_STREAM__");
+    }
+
+    @Test
+    @DisplayName("queues completion event and sentinel for normal flow")
+    void normalCompletion_queuesCompletionAndSentinel() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>();
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+      AtomicBoolean chunksReceived = new AtomicBoolean(true);
+      AtomicInteger chunkCount = new AtomicInteger(3);
+      AtomicLong timeToFirstChunk = new AtomicLong(150);
+
+      invokeHandleStreamComplete(
+                                 "session1", "agentId", "alias", System.currentTimeMillis() - 2000,
+                                 "req1", "corr1", "user1",
+                                 chunkCount, timeToFirstChunk, chunksReceived, writeQueue, clientDisconnected);
+
+      // Should have completion event + sentinel
+      assertThat(writeQueue.size()).isEqualTo(2);
+      String completionEvent = writeQueue.poll();
+      assertThat(completionEvent).contains("session-complete");
+      assertThat(completionEvent).contains("completed");
+      assertThat(completionEvent).contains("req1");
+      assertThat(completionEvent).contains("corr1");
+      assertThat(completionEvent).contains("user1");
+      assertThat(writeQueue.poll()).isEqualTo("__END_OF_STREAM__");
+    }
+
+    @Test
+    @DisplayName("queues completion event with queue size > 25 (L1256-1258, L1282-1284)")
+    void queueOverflow_logsAndQueuesNormally() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>();
+      // Pre-fill with 26 items
+      for (int i = 0; i < 26; i++) {
+        writeQueue.offer("event-" + i);
       }
-    } catch (Exception ignored) {
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+      AtomicBoolean chunksReceived = new AtomicBoolean(true);
+      AtomicInteger chunkCount = new AtomicInteger(3);
+      AtomicLong timeToFirstChunk = new AtomicLong(150);
+
+      invokeHandleStreamComplete(
+                                 "session1", "agentId", "alias", System.currentTimeMillis() - 2000,
+                                 "req1", "corr1", "user1",
+                                 chunkCount, timeToFirstChunk, chunksReceived, writeQueue, clientDisconnected);
+
+      // 26 pre-filled + 1 completion + 1 sentinel
+      assertThat(writeQueue.size()).isEqualTo(28);
     }
-    return null;
   }
 
-  @Test
-  @DisplayName("chatWithAgentSSEStream returns non-null InputStream")
-  void chatWithAgentSSEStreamReturnsInputStream() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== writeChunkErrorEvent ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("writeChunkErrorEvent")
+  class WriteChunkErrorEvent {
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    InputStream stream = service.chatWithAgentSSEStream(
-                                                        "agentId", "aliasId", "Hi", false, false,
-                                                        sessionParams, null, null, responseParams, null);
+    @Test
+    @DisplayName("queues chunk-error SSE event to write queue (L1217-1220)")
+    void queuesErrorEvent() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>();
+      IOException error = new IOException("chunk write failed");
 
-    assertThat(stream).isNotNull();
-  }
+      Method m = AgentServiceImpl.class.getDeclaredMethod("writeChunkErrorEvent",
+                                                          IOException.class, BlockingQueue.class);
+      m.setAccessible(true);
+      m.invoke(service, error, writeQueue);
 
-  @Test
-  @DisplayName("chatWithAgentSSEStream writes error event when invokeAgent fails")
-  void chatWithAgentSSEStreamWritesErrorWhenInvokeFails() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    CompletableFuture<Void> failingFuture = new CompletableFuture<>();
-    failingFuture
-        .completeExceptionally(new java.util.concurrent.ExecutionException("stream fail", new RuntimeException("cause")));
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(failingFuture);
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    InputStream stream = service.chatWithAgentSSEStream(
-                                                        "agentId", "aliasId", "Hi", false, false,
-                                                        sessionParams, null, null, responseParams, null);
-    assertThat(stream).isNotNull();
-    byte[] buf = new byte[8192];
-    int total = 0;
-    long deadline = System.currentTimeMillis() + 5000;
-    while (total < buf.length && System.currentTimeMillis() < deadline) {
-      int n = stream.read(buf, total, buf.length - total);
-      if (n <= 0)
-        break;
-      total += n;
-      String soFar = new String(buf, 0, total, java.nio.charset.StandardCharsets.UTF_8);
-      if (soFar.contains("event:") && soFar.contains("error"))
-        break;
+      assertThat(writeQueue.size()).isEqualTo(1);
+      String event = writeQueue.poll();
+      assertThat(event).contains("chunk-error");
+      assertThat(event).contains("chunk write failed");
     }
-    String content = new String(buf, 0, total, java.nio.charset.StandardCharsets.UTF_8);
-    assertThat(content).contains("event:");
-    assertThat(content).as("stream should contain error event when invoke fails").contains("error");
   }
 
-  @Test
-  @DisplayName("chatWithAgent throws when invokeAgent completes exceptionally")
-  void chatWithAgentThrowsWhenInvokeAgentFails() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    CompletableFuture<Void> failingFuture = new CompletableFuture<>();
-    failingFuture.completeExceptionally(new RuntimeException("agent error"));
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(failingFuture);
+  // ==================== writeSessionStartEvent ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("writeSessionStartEvent")
+  class WriteSessionStartEvent {
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    org.assertj.core.api.Assertions.assertThatThrownBy(
-                                                       () -> service.chatWithAgent(
-                                                                                   "agentId", "aliasId", "Hi", false, false,
-                                                                                   sessionParams, null, null, responseParams,
-                                                                                   null))
-        .hasMessageContaining("agent error");
+    @Test
+    @DisplayName("queues session-start event with queue > 25 items (L1209-1211)")
+    void queueOverflow_logsAndQueues() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>();
+      for (int i = 0; i < 26; i++) {
+        writeQueue.offer("event-" + i);
+      }
+
+      Method m = AgentServiceImpl.class.getDeclaredMethod("writeSessionStartEvent",
+                                                          String.class, String.class, String.class, String.class,
+                                                          String.class, String.class, String.class,
+                                                          long.class, BlockingQueue.class);
+      m.setAccessible(true);
+      m.invoke(service, "alias", "agentId", "prompt", "session1",
+               "req1", "corr1", "user1", 100L, writeQueue);
+
+      // 26 pre-filled + 1 session-start
+      assertThat(writeQueue.size()).isEqualTo(27);
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgent with multiple KB and legacy params set hits warn path")
-  void chatWithAgentMultipleKbWithLegacyParamsIgnored() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== createChunkJson ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("createChunkJson")
+  class CreateChunkJson {
 
-    BedrockAgentsFilteringParameters legacyParams = new BedrockAgentsFilteringParameters();
-    IntegrationTestParamHelper.setField(legacyParams, "knowledgeBaseId", "legacy-kb");
-    IntegrationTestParamHelper.setField(legacyParams, "numberOfResults", 5);
+    @Test
+    @DisplayName("adds error field when chunk.bytes() throws (L1332-1333)")
+    void exceptionFromBytes_addsErrorToJson() throws Exception {
+      PayloadPart chunk = mock(PayloadPart.class);
+      when(chunk.bytes()).thenThrow(new RuntimeException("bytes decode failure"));
 
-    BedrockAgentsFilteringParameters.KnowledgeBaseConfig kbConfig =
-        new BedrockAgentsFilteringParameters.KnowledgeBaseConfig("kb-1", 10,
-                                                                 BedrockAgentsFilteringParameters.SearchType.HYBRID, null, null);
-    BedrockAgentsMultipleFilteringParameters multipleParams = new BedrockAgentsMultipleFilteringParameters();
-    IntegrationTestParamHelper.setField(multipleParams, "knowledgeBases", Collections.singletonList(kbConfig));
+      Method m = AgentServiceImpl.class.getDeclaredMethod("createChunkJson", PayloadPart.class);
+      m.setAccessible(true);
+      JSONObject result = (JSONObject) m.invoke(service, chunk);
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, legacyParams, multipleParams, responseParams, null);
+      assertThat(result.getString("type")).isEqualTo("chunk");
+      assertThat(result.has("timestamp")).isTrue();
+      assertThat(result.getString("error")).contains("bytes decode failure");
+    }
 
-    assertThat(result).isNotBlank();
+    @Test
+    @DisplayName("creates valid JSON for normal chunk")
+    void normalChunk_createsValidJson() throws Exception {
+      PayloadPart chunk = PayloadPart.builder()
+          .bytes(SdkBytes.fromUtf8String("Hello world"))
+          .build();
+
+      Method m = AgentServiceImpl.class.getDeclaredMethod("createChunkJson", PayloadPart.class);
+      m.setAccessible(true);
+      JSONObject result = (JSONObject) m.invoke(service, chunk);
+
+      assertThat(result.getString("type")).isEqualTo("chunk");
+      assertThat(result.getString("text")).isEqualTo("Hello world");
+      assertThat(result.has("timestamp")).isTrue();
+    }
+
+    @Test
+    @DisplayName("handles chunk with null bytes")
+    void nullBytes_noTextField() throws Exception {
+      PayloadPart chunk = PayloadPart.builder().build();
+
+      Method m = AgentServiceImpl.class.getDeclaredMethod("createChunkJson", PayloadPart.class);
+      m.setAccessible(true);
+      JSONObject result = (JSONObject) m.invoke(service, chunk);
+
+      assertThat(result.getString("type")).isEqualTo("chunk");
+      assertThat(result.has("text")).isFalse();
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgent with legacy filtering and empty knowledgeBaseId returns null config")
-  void chatWithAgentLegacyEmptyKnowledgeBaseId() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== closeQuietly ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("closeQuietly")
+  class CloseQuietly {
 
-    BedrockAgentsFilteringParameters filteringParams = new BedrockAgentsFilteringParameters();
-    IntegrationTestParamHelper.setField(filteringParams, "knowledgeBaseId", "");
+    @Test
+    @DisplayName("handles null stream without throwing (L943-944)")
+    void nullStream_doesNotThrow() throws Exception {
+      Method m = AgentServiceImpl.class.getDeclaredMethod("closeQuietly", PipedOutputStream.class);
+      m.setAccessible(true);
+      Object result = m.invoke(service, (PipedOutputStream) null);
+      assertThat(result).isNull();
+    }
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, filteringParams, null, responseParams, null);
+    @Test
+    @DisplayName("handles already-closed stream without throwing (L945-947)")
+    void alreadyClosedStream_doesNotThrow() throws Exception {
+      Method m = AgentServiceImpl.class.getDeclaredMethod("closeQuietly", PipedOutputStream.class);
+      m.setAccessible(true);
 
-    assertThat(result).isNotBlank();
+      PipedOutputStream os = new PipedOutputStream();
+      os.close();
+      Object result = m.invoke(service, os);
+      assertThat(result).isNull();
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgent with legacy only numberOfResults uses buildVectorSearchConfiguration")
-  void chatWithAgentLegacyOnlyNumberOfResults() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== toDuration ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("toDuration")
+  class ToDuration {
 
-    BedrockAgentsFilteringParameters filteringParams = new BedrockAgentsFilteringParameters();
-    IntegrationTestParamHelper.setField(filteringParams, "knowledgeBaseId", "kb-1");
-    IntegrationTestParamHelper.setField(filteringParams, "numberOfResults", 8);
-    IntegrationTestParamHelper.setField(filteringParams, "metadataFilters", null);
-    IntegrationTestParamHelper.setField(filteringParams, "overrideSearchType", null);
+    @Test
+    @DisplayName("defaults to seconds when TimeUnit is null (L466)")
+    void nullUnit_defaultsToSeconds() throws Exception {
+      Method m = AgentServiceImpl.class.getDeclaredMethod("toDuration", int.class, TimeUnit.class);
+      m.setAccessible(true);
+      Duration result = (Duration) m.invoke(null, 30, (TimeUnit) null);
+      assertThat(result).isEqualTo(Duration.ofSeconds(30));
+    }
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, filteringParams, null, responseParams, null);
-
-    assertThat(result).isNotBlank();
+    @Test
+    @DisplayName("converts milliseconds correctly when unit is provided")
+    void withUnit_convertsCorrectly() throws Exception {
+      Method m = AgentServiceImpl.class.getDeclaredMethod("toDuration", int.class, TimeUnit.class);
+      m.setAccessible(true);
+      Duration result = (Duration) m.invoke(null, 5000, TimeUnit.MILLISECONDS);
+      assertThat(result).isEqualTo(Duration.ofMillis(5000));
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgent with legacy only overrideSearchType uses buildVectorSearchConfiguration")
-  void chatWithAgentLegacyOnlyOverrideSearchType() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== createErrorJson ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("createErrorJson")
+  class CreateErrorJson {
 
-    BedrockAgentsFilteringParameters filteringParams = new BedrockAgentsFilteringParameters();
-    IntegrationTestParamHelper.setField(filteringParams, "knowledgeBaseId", "kb-1");
-    IntegrationTestParamHelper.setField(filteringParams, "numberOfResults", null);
-    IntegrationTestParamHelper.setField(filteringParams, "metadataFilters", null);
-    IntegrationTestParamHelper.setField(filteringParams, "overrideSearchType",
-                                        BedrockAgentsFilteringParameters.SearchType.SEMANTIC);
+    @Test
+    @DisplayName("produces valid JSON with error message, type, and timestamp")
+    void producesValidJson() throws Exception {
+      Method m = AgentServiceImpl.class.getDeclaredMethod("createErrorJson", Throwable.class);
+      m.setAccessible(true);
+      JSONObject result = (JSONObject) m.invoke(null, new IOException("test IO error"));
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, filteringParams, null, responseParams, null);
-
-    assertThat(result).isNotBlank();
+      assertThat(result.getString("error")).isEqualTo("test IO error");
+      assertThat(result.getString("type")).isEqualTo("IOException");
+      assertThat(result.has("timestamp")).isTrue();
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgent with legacy single metadata filter uses buildVectorSearchConfiguration")
-  void chatWithAgentLegacySingleMetadataFilter() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== formatSSEEvent ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("formatSSEEvent")
+  class FormatSSEEvent {
 
-    BedrockAgentsFilteringParameters filteringParams = new BedrockAgentsFilteringParameters();
-    IntegrationTestParamHelper.setField(filteringParams, "knowledgeBaseId", "kb-1");
-    IntegrationTestParamHelper.setField(filteringParams, "numberOfResults", 5);
-    IntegrationTestParamHelper.setField(filteringParams, "metadataFilters",
-                                        java.util.Collections.singletonMap("key1", "value1"));
+    @Test
+    @DisplayName("produces correctly formatted SSE with id, event, and data")
+    void producesCorrectFormat() throws Exception {
+      Method m = AgentServiceImpl.class.getDeclaredMethod("formatSSEEvent", String.class, String.class);
+      m.setAccessible(true);
+      String result = (String) m.invoke(service, "test-event", "{\"key\":\"value\"}");
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, filteringParams, null, responseParams, null);
-
-    assertThat(result).isNotBlank();
+      assertThat(result).contains("id:");
+      assertThat(result).contains("event: test-event");
+      assertThat(result).contains("data: {\"key\":\"value\"}");
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgent with legacy multiple metadata filters AND_ALL")
-  void chatWithAgentLegacyMultipleFiltersAndAll() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== handleStreamChunk - queue full paths ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("handleStreamChunk - queue full")
+  class HandleStreamChunkQueueFull {
 
-    java.util.Map<String, String> filters = new java.util.HashMap<>();
-    filters.put("k1", "v1");
-    filters.put("k2", "v2");
-    BedrockAgentsFilteringParameters filteringParams = new BedrockAgentsFilteringParameters();
-    IntegrationTestParamHelper.setField(filteringParams, "knowledgeBaseId", "kb-1");
-    IntegrationTestParamHelper.setField(filteringParams, "metadataFilters", filters);
-    IntegrationTestParamHelper.setField(filteringParams, "retrievalMetadataFilterType",
-                                        BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.AND_ALL);
+    @Test
+    @DisplayName("drops chunk when queue is full (L1079-1080)")
+    void queueFull_dropsChunkEvent() throws Exception {
+      // Use a queue with capacity 1, pre-fill it so offer() returns false
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>(1);
+      writeQueue.offer("existing-event");
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, filteringParams, null, responseParams, null);
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+      AtomicBoolean chunksReceived = new AtomicBoolean(true);
+      AtomicBoolean sessionStartSent = new AtomicBoolean(true);
+      AtomicInteger chunkCount = new AtomicInteger(1);
+      AtomicLong lastChunkTime = new AtomicLong(System.currentTimeMillis());
+      AtomicLong timeToFirstChunk = new AtomicLong(100);
 
-    assertThat(result).isNotBlank();
+      PayloadPart chunk = PayloadPart.builder()
+          .bytes(SdkBytes.fromUtf8String("dropped chunk"))
+          .build();
+
+      invokeHandleStreamChunk(
+                              "alias", "agentId", "prompt", "session1", "req1", "corr1", "user1",
+                              chunksReceived, sessionStartSent, System.currentTimeMillis(),
+                              writeQueue, chunk, chunkCount, lastChunkTime, timeToFirstChunk, clientDisconnected);
+
+      // Queue still has only the original event — chunk was dropped
+      assertThat(writeQueue.size()).isEqualTo(1);
+      assertThat(writeQueue.peek()).isEqualTo("existing-event");
+      // But chunk count was still incremented
+      assertThat(chunkCount.get()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("drops session-start when queue is full on first chunk (L1096)")
+    void queueFull_dropsSessionStartEvent() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>(1);
+      writeQueue.offer("existing-event");
+
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+      AtomicBoolean chunksReceived = new AtomicBoolean(false);
+      AtomicBoolean sessionStartSent = new AtomicBoolean(false);
+      AtomicInteger chunkCount = new AtomicInteger(0);
+      AtomicLong lastChunkTime = new AtomicLong(System.currentTimeMillis());
+      AtomicLong timeToFirstChunk = new AtomicLong(-1);
+
+      PayloadPart chunk = PayloadPart.builder()
+          .bytes(SdkBytes.fromUtf8String("first chunk"))
+          .build();
+
+      invokeHandleStreamChunk(
+                              "alias", "agentId", "prompt", "session1", "req1", "corr1", "user1",
+                              chunksReceived, sessionStartSent, System.currentTimeMillis(),
+                              writeQueue, chunk, chunkCount, lastChunkTime, timeToFirstChunk, clientDisconnected);
+
+      // session-start couldn't be queued, chunk also couldn't be queued
+      assertThat(writeQueue.size()).isEqualTo(1);
+      assertThat(sessionStartSent.get()).isTrue();
+      assertThat(chunksReceived.get()).isTrue();
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgent with legacy multiple metadata filters OR_ALL")
-  void chatWithAgentLegacyMultipleFiltersOrAll() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== writeChunkErrorEvent - queue full ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("writeChunkErrorEvent - queue full")
+  class WriteChunkErrorEventQueueFull {
 
-    java.util.Map<String, String> filters = new java.util.HashMap<>();
-    filters.put("a", "1");
-    filters.put("b", "2");
-    BedrockAgentsFilteringParameters filteringParams = new BedrockAgentsFilteringParameters();
-    IntegrationTestParamHelper.setField(filteringParams, "knowledgeBaseId", "kb-1");
-    IntegrationTestParamHelper.setField(filteringParams, "metadataFilters", filters);
-    IntegrationTestParamHelper.setField(filteringParams, "retrievalMetadataFilterType",
-                                        BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.OR_ALL);
+    @Test
+    @DisplayName("drops chunk-error event when queue is full (L1104)")
+    void queueFull_dropsChunkErrorEvent() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>(1);
+      writeQueue.offer("existing-event");
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, filteringParams, null, responseParams, null);
+      Method m = AgentServiceImpl.class.getDeclaredMethod("writeChunkErrorEvent",
+                                                          IOException.class, BlockingQueue.class);
+      m.setAccessible(true);
+      m.invoke(service, new IOException("test error"), writeQueue);
 
-    assertThat(result).isNotBlank();
+      // Queue still has only the original event — error was dropped
+      assertThat(writeQueue.size()).isEqualTo(1);
+      assertThat(writeQueue.peek()).isEqualTo("existing-event");
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgent with KB config reranking and SELECTIVE fieldsToExclude")
-  void chatWithAgentRerankingSelectiveFieldsToExclude() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== handleStreamComplete - queue full paths ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("handleStreamComplete - queue full")
+  class HandleStreamCompleteQueueFull {
 
-    BedrockAgentsFilteringParameters.RerankingConfiguration reranking =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    reranking.setModelArn("arn:aws:bedrock:us-east-1::foundation-model/rerank-model");
-    reranking.setSelectionMode(BedrockAgentsFilteringParameters.RerankingSelectionMode.SELECTIVE);
-    reranking.setFieldsToExclude(java.util.Collections.singletonList("score"));
+    @Test
+    @DisplayName("drops completion event when queue is full (L1136)")
+    void queueFull_dropsCompletionEvent() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>(2);
+      writeQueue.offer("event-1");
+      writeQueue.offer("event-2");
 
-    BedrockAgentsFilteringParameters.KnowledgeBaseConfig kbConfig =
-        new BedrockAgentsFilteringParameters.KnowledgeBaseConfig("kb-1", 10,
-                                                                 BedrockAgentsFilteringParameters.SearchType.HYBRID, null, null);
-    kbConfig.setRerankingConfiguration(reranking);
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+      AtomicBoolean chunksReceived = new AtomicBoolean(true);
+      AtomicInteger chunkCount = new AtomicInteger(3);
+      AtomicLong timeToFirstChunk = new AtomicLong(150);
 
-    BedrockAgentsMultipleFilteringParameters multipleParams = new BedrockAgentsMultipleFilteringParameters();
-    IntegrationTestParamHelper.setField(multipleParams, "knowledgeBases", Collections.singletonList(kbConfig));
+      invokeHandleStreamComplete(
+                                 "session1", "agentId", "alias", System.currentTimeMillis() - 1000,
+                                 "req1", "corr1", "user1",
+                                 chunkCount, timeToFirstChunk, chunksReceived, writeQueue, clientDisconnected);
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, multipleParams, responseParams, null);
+      // Completion event was dropped, but sentinel was force-queued (drains one item to make room)
+      // Original: [event-1, event-2] -> completion dropped -> sentinel: poll event-1, offer sentinel
+      // Result: [event-2, __END_OF_STREAM__]
+      assertThat(writeQueue.size()).isEqualTo(2);
+      String first = writeQueue.poll();
+      String second = writeQueue.poll();
+      assertThat(second).isEqualTo("__END_OF_STREAM__");
+    }
 
-    assertThat(result).isNotBlank();
+    @Test
+    @DisplayName("forces sentinel when queue is full by draining one item (L1151-1154)")
+    void queueFull_forcesSentinel() throws Exception {
+      // Queue capacity 1, pre-fill it
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>(1);
+      writeQueue.offer("blocking-event");
+
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+      AtomicBoolean chunksReceived = new AtomicBoolean(true);
+      AtomicInteger chunkCount = new AtomicInteger(3);
+      AtomicLong timeToFirstChunk = new AtomicLong(150);
+
+      invokeHandleStreamComplete(
+                                 "session1", "agentId", "alias", System.currentTimeMillis() - 1000,
+                                 "req1", "corr1", "user1",
+                                 chunkCount, timeToFirstChunk, chunksReceived, writeQueue, clientDisconnected);
+
+      // Sentinel must be present — it was force-queued after draining
+      assertThat(writeQueue.size()).isEqualTo(1);
+      assertThat(writeQueue.poll()).isEqualTo("__END_OF_STREAM__");
+    }
+
+    @Test
+    @DisplayName("queues completion-error and sentinel when completion JSON creation fails (L1140-1144)")
+    void completionJsonException_queuesErrorAndSentinel() throws Exception {
+      // Use a queue with plenty of space — we want the error path, not queue-full path
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>(100);
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+      AtomicBoolean chunksReceived = new AtomicBoolean(true);
+      // null chunkCount will cause NPE in createCompletionJson
+      AtomicLong timeToFirstChunk = new AtomicLong(150);
+
+      invokeHandleStreamComplete(
+                                 "session1", "agentId", "alias", System.currentTimeMillis() - 1000,
+                                 "req1", "corr1", "user1",
+                                 null, timeToFirstChunk, chunksReceived, writeQueue, clientDisconnected);
+
+      // Should have completion-error + sentinel
+      assertThat(writeQueue.size()).isGreaterThanOrEqualTo(1);
+      String allEvents = drainQueue(writeQueue);
+      assertThat(allEvents).contains("__END_OF_STREAM__");
+    }
+
+    @Test
+    @DisplayName("forces sentinel when queue full during client disconnect (L1121)")
+    void clientDisconnected_queueFull_forcesSentinel() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>(1);
+      writeQueue.offer("blocking-event");
+
+      AtomicBoolean clientDisconnected = new AtomicBoolean(true);
+      AtomicBoolean chunksReceived = new AtomicBoolean(true);
+      AtomicInteger chunkCount = new AtomicInteger(3);
+      AtomicLong timeToFirstChunk = new AtomicLong(150);
+
+      invokeHandleStreamComplete(
+                                 "session1", "agentId", "alias", System.currentTimeMillis() - 1000,
+                                 "req1", "corr1", "user1",
+                                 chunkCount, timeToFirstChunk, chunksReceived, writeQueue, clientDisconnected);
+
+      // Sentinel was force-queued (drained blocking-event)
+      assertThat(writeQueue.size()).isEqualTo(1);
+      assertThat(writeQueue.poll()).isEqualTo("__END_OF_STREAM__");
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgent with KB config reranking and fieldsToInclude")
-  void chatWithAgentRerankingFieldsToInclude() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== writeSessionStartEvent - queue full ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("writeSessionStartEvent - queue full")
+  class WriteSessionStartEventQueueFull {
 
-    BedrockAgentsFilteringParameters.RerankingConfiguration reranking =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    reranking.setModelArn("arn:aws:bedrock:us-east-1::foundation-model/rerank");
-    reranking.setSelectionMode(BedrockAgentsFilteringParameters.RerankingSelectionMode.SELECTIVE);
-    reranking.setFieldsToInclude(java.util.Collections.singletonList("content"));
+    @Test
+    @DisplayName("throws IOException when queue is full")
+    void queueFull_throwsIOException() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>(1);
+      writeQueue.offer("existing-event");
 
-    BedrockAgentsFilteringParameters.KnowledgeBaseConfig kbConfig =
-        new BedrockAgentsFilteringParameters.KnowledgeBaseConfig("kb-1", 5, null, null, null);
-    kbConfig.setRerankingConfiguration(reranking);
+      Method m = AgentServiceImpl.class.getDeclaredMethod("writeSessionStartEvent",
+                                                          String.class, String.class, String.class, String.class,
+                                                          String.class, String.class, String.class,
+                                                          long.class, BlockingQueue.class);
+      m.setAccessible(true);
 
-    BedrockAgentsMultipleFilteringParameters multipleParams = new BedrockAgentsMultipleFilteringParameters();
-    IntegrationTestParamHelper.setField(multipleParams, "knowledgeBases", Collections.singletonList(kbConfig));
+      Throwable thrown = org.assertj.core.api.Assertions.catchThrowable(
+                                                                        () -> m.invoke(service, "alias", "agentId", "prompt",
+                                                                                       "session1",
+                                                                                       "req1", "corr1", "user1", 100L,
+                                                                                       writeQueue));
+      assertThat(thrown).isInstanceOf(InvocationTargetException.class);
+      assertThat(thrown.getCause())
+          .isInstanceOf(IOException.class)
+          .hasMessageContaining("Failed to queue session-start event");
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, multipleParams, responseParams, null);
-
-    assertThat(result).isNotBlank();
+      // Queue still has only the original event
+      assertThat(writeQueue.size()).isEqualTo(1);
+      assertThat(writeQueue.peek()).isEqualTo("existing-event");
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgent with KB config reranking numberOfRerankedResults and additionalModelRequestFields")
-  void chatWithAgentRerankingNumberOfRerankedResultsAndAdditionalFields() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== buildKnowledgeBaseConfigs ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("buildKnowledgeBaseConfigs")
+  class BuildKnowledgeBaseConfigs {
 
-    BedrockAgentsFilteringParameters.RerankingConfiguration reranking =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    reranking.setModelArn("arn:aws:bedrock:us-east-1::foundation-model/rerank");
-    reranking.setRerankingType("CUSTOM");
-    reranking.setNumberOfRerankedResults(15);
-    reranking.setAdditionalModelRequestFields(java.util.Collections.singletonMap("key", "value"));
+    @Test
+    @DisplayName("returns null when legacyParams is null (L297)")
+    void legacyParamsNull_returnsNull() throws Exception {
+      Method m = AgentServiceImpl.class.getDeclaredMethod("buildKnowledgeBaseConfigs",
+                                                          BedrockAgentsFilteringParameters.class,
+                                                          BedrockAgentsMultipleFilteringParameters.class);
+      m.setAccessible(true);
+      Object result = m.invoke(null, (Object) null, (Object) null);
+      assertThat(result).isNull();
+    }
 
-    BedrockAgentsFilteringParameters.KnowledgeBaseConfig kbConfig =
-        new BedrockAgentsFilteringParameters.KnowledgeBaseConfig("kb-1", 10, null, null, null);
-    kbConfig.setRerankingConfiguration(reranking);
+    @Test
+    @DisplayName("returns null when legacyParams has empty knowledgeBaseId")
+    void emptyKnowledgeBaseId_returnsNull() throws Exception {
+      Method m = AgentServiceImpl.class.getDeclaredMethod("buildKnowledgeBaseConfigs",
+                                                          BedrockAgentsFilteringParameters.class,
+                                                          BedrockAgentsMultipleFilteringParameters.class);
+      m.setAccessible(true);
 
-    BedrockAgentsMultipleFilteringParameters multipleParams = new BedrockAgentsMultipleFilteringParameters();
-    IntegrationTestParamHelper.setField(multipleParams, "knowledgeBases", Collections.singletonList(kbConfig));
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, multipleParams, responseParams, null);
-
-    assertThat(result).isNotBlank();
+      BedrockAgentsFilteringParameters legacyParams = new BedrockAgentsFilteringParameters();
+      IntegrationTestParamHelper.setField(legacyParams, "knowledgeBaseId", "");
+      Object result = m.invoke(null, legacyParams, (Object) null);
+      assertThat(result).isNull();
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgent with requestTimeout in minutes uses toDuration MINUTES")
-  void chatWithAgentTimeoutMinutes() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== convertToSdkSearchType ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(2, TimeUnit.MINUTES, false, 2, 1000L);
+  @Nested
+  @DisplayName("convertToSdkSearchType")
+  class ConvertToSdkSearchType {
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, null, responseParams, null);
-
-    assertThat(result).isNotBlank();
+    @Test
+    @DisplayName("returns null for null input (L674)")
+    void nullInput_returnsNull() throws Exception {
+      Method m = AgentServiceImpl.class.getDeclaredMethod("convertToSdkSearchType",
+                                                          BedrockAgentsFilteringParameters.SearchType.class);
+      m.setAccessible(true);
+      Object result = m.invoke(null, (Object) null);
+      assertThat(result).isNull();
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgentSSEStream with response logging params uses requestId correlationId userId")
-  void chatWithAgentSSEStreamWithResponseLoggingParams() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== definePromptTemplate error path ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
-    BedrockAgentsResponseLoggingParameters loggingParams =
-        new BedrockAgentsResponseLoggingParameters();
-    IntegrationTestParamHelper.setField(loggingParams, "requestId", "req-123");
-    IntegrationTestParamHelper.setField(loggingParams, "correlationId", "corr-456");
-    IntegrationTestParamHelper.setField(loggingParams, "userId", "user-789");
+  @Nested
+  @DisplayName("definePromptTemplate")
+  class DefinePromptTemplate {
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    InputStream stream = service.chatWithAgentSSEStream(
-                                                        "agentId", "aliasId", "Hi", false, false,
-                                                        sessionParams, null, null, responseParams, loggingParams);
+    @Test
+    @DisplayName("throws ModuleException when SdkClientException occurs (L185-186)")
+    void sdkClientException_throwsModuleException() {
+      when(mockConnection.answerPrompt(any()))
+          .thenThrow(SdkClientException.builder().message("network error").build());
 
-    assertThat(stream).isNotNull();
+      com.mulesoft.connectors.bedrock.internal.parameter.BedrockParameters params =
+          IntegrationTestParamHelper.bedrockParams("amazon.nova-lite-v1:0", 0.5f, 50);
+
+      org.assertj.core.api.Assertions.assertThatThrownBy(
+                                                         () -> service.definePromptTemplate(
+                                                                                            "Instructions: {{instructions}}. Data: {{dataset}}.",
+                                                                                            "Answer briefly.", "Sample data",
+                                                                                            params))
+          .isInstanceOf(org.mule.runtime.extension.api.exception.ModuleException.class);
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgentSSEStream with empty sessionId generates UUID")
-  void chatWithAgentSSEStreamEmptySessionId() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== buildRetrievedReferenceJson ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("buildRetrievedReferenceJson")
+  class BuildRetrievedReferenceJson {
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    InputStream stream = service.chatWithAgentSSEStream(
-                                                        "agentId", "aliasId", "Hi", false, false,
-                                                        sessionParams, null, null, responseParams, null);
+    @Test
+    @DisplayName("builds JSON with content, location, and metadata (L411-421)")
+    void fullReference_buildsCompleteJson() throws Exception {
+      RetrievedReference ref = mock(RetrievedReference.class, RETURNS_DEEP_STUBS);
+      when(ref.content().text()).thenReturn("reference text");
+      when(ref.location().toString()).thenReturn("s3://bucket/key");
+      Map<String, software.amazon.awssdk.core.document.Document> metadata = new HashMap<>();
+      metadata.put("source", software.amazon.awssdk.core.document.Document.fromString("test-doc"));
+      when(ref.metadata()).thenReturn(metadata);
 
-    assertThat(stream).isNotNull();
+      Method m = AgentServiceImpl.class.getDeclaredMethod("buildRetrievedReferenceJson",
+                                                          RetrievedReference.class);
+      m.setAccessible(true);
+      JSONObject result = (JSONObject) m.invoke(service, ref);
+
+      assertThat(result.getString("content")).isEqualTo("reference text");
+      assertThat(result.getString("location")).isEqualTo("s3://bucket/key");
+      assertThat(result.has("metadata")).isTrue();
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgentSSEStream delivers chunk with text via onChunk handler")
-  void chatWithAgentSSEStreamWithChunkDelivery() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== buildVectorSearchConfiguration - reranking ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("buildVectorSearchConfiguration - reranking")
+  class RerankingConfig {
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    InputStream stream = service.chatWithAgentSSEStream(
-                                                        "agentId", "aliasId", "Hi", false, false,
-                                                        sessionParams, null, null, responseParams, null);
+    @Test
+    @DisplayName("configures reranking with additionalModelRequestFields (L622-624) and null selectionMode (L637)")
+    void rerankingWithAdditionalFields_nullSelectionMode() throws Exception {
+      BedrockAgentsFilteringParameters.RerankingConfiguration reranking =
+          new BedrockAgentsFilteringParameters.RerankingConfiguration();
+      reranking.setModelArn("arn:aws:bedrock:us-east-1:123:inference-profile/test");
+      reranking.setRerankingType("BEDROCK");
+      Map<String, String> additionalFields = new HashMap<>();
+      additionalFields.put("topK", "5");
+      reranking.setAdditionalModelRequestFields(additionalFields);
+      // selectionMode is null -> covers L637 (early return in applyMetadataRerankingConfiguration)
 
-    assertThat(stream).isNotNull();
+      Method m = AgentServiceImpl.class.getDeclaredMethod("buildVectorSearchConfiguration",
+                                                          Integer.class,
+                                                          BedrockAgentsFilteringParameters.SearchType.class,
+                                                          BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.class,
+                                                          Map.class,
+                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
+      m.setAccessible(true);
+      Object result = m.invoke(null, null, null, null, null, reranking);
+
+      assertThat(result).isNotNull();
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgentSSEStream delivers chunk with null bytes")
-  void chatWithAgentSSEStreamChunkWithNullBytes() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenAnswer(invocation -> {
-      InvokeAgentResponseHandler handler = invocation.getArgument(1);
-      CompletableFuture<Void> future = new CompletableFuture<>();
+  // ==================== closeQuietly - IOException ====================
+
+  @Nested
+  @DisplayName("closeQuietly - IOException")
+  class CloseQuietlyIOException {
+
+    @Test
+    @DisplayName("catches IOException from close and logs without propagating (L885-886)")
+    void closeThrowsIOException_doesNotPropagate() throws Exception {
+      PipedOutputStream mockOs = mock(PipedOutputStream.class);
+      doThrow(new IOException("close failed")).when(mockOs).close();
+
+      Method m = AgentServiceImpl.class.getDeclaredMethod("closeQuietly", PipedOutputStream.class);
+      m.setAccessible(true);
+      // Should not throw - IOException is caught and logged
+      Object result = m.invoke(service, mockOs);
+      assertThat(result).isNull();
+    }
+  }
+
+  // ==================== handleStreamComplete - completion error with queue full ====================
+
+  @Nested
+  @DisplayName("handleStreamComplete - completion error with queue full")
+  class CompletionErrorQueueFull {
+
+    @Test
+    @DisplayName("drops completion-error event when queue is full (L1144)")
+    void completionError_queueFull_dropsErrorEvent() throws Exception {
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>(1);
+      writeQueue.offer("existing-event");
+
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+      AtomicBoolean chunksReceived = new AtomicBoolean(true);
+      // null chunkCount triggers NPE in createCompletionJson -> enters catch block
+      AtomicLong timeToFirstChunk = new AtomicLong(150);
+
+      invokeHandleStreamComplete(
+                                 "session1", "agentId", "alias", System.currentTimeMillis() - 1000,
+                                 "req1", "corr1", "user1",
+                                 null, timeToFirstChunk, chunksReceived, writeQueue, clientDisconnected);
+
+      // Completion-error dropped (queue full, L1144), sentinel force-queued (drains existing)
+      assertThat(writeQueue.size()).isEqualTo(1);
+      assertThat(writeQueue.poll()).isEqualTo("__END_OF_STREAM__");
+    }
+  }
+
+  // ==================== streamBedrockResponse - client disconnect paths ====================
+
+  @Nested
+  @DisplayName("streamBedrockResponse - client disconnect")
+  class StreamBedrockResponseClientDisconnect {
+
+    @Test
+    @DisplayName("logs when Bedrock completes but client already disconnected (L993)")
+    void completedFuture_clientDisconnected() throws Exception {
+      when(mockConnection.invokeAgent(
+                                      any(InvokeAgentRequest.class), any(InvokeAgentResponseHandler.class), anyLong()))
+          .thenReturn(CompletableFuture.completedFuture(null));
+
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>();
+      AtomicBoolean clientDisconnected = new AtomicBoolean(true);
+
+      invokeStreamBedrockResponse(writeQueue, clientDisconnected);
+      // Method returns normally; L993 (debug log for client disconnected) was hit
+    }
+
+    @Test
+    @DisplayName("suppresses error and force-queues sentinel when client disconnected (L1006-1012)")
+    void failedFuture_clientDisconnected_queuesSentinel() throws Exception {
+      when(mockConnection.invokeAgent(
+                                      any(InvokeAgentRequest.class), any(InvokeAgentResponseHandler.class), anyLong()))
+          .thenReturn(CompletableFuture.failedFuture(new RuntimeException("bedrock error")));
+
+      BlockingQueue<String> writeQueue = new LinkedBlockingQueue<>(1);
+      writeQueue.offer("existing-event"); // fill queue to trigger L1008-1010 (force sentinel)
+      AtomicBoolean clientDisconnected = new AtomicBoolean(true);
+
+      invokeStreamBedrockResponse(writeQueue, clientDisconnected);
+
+      // Error suppressed, sentinel force-queued (drained existing)
+      assertThat(writeQueue.size()).isEqualTo(1);
+      assertThat(writeQueue.poll()).isEqualTo("__END_OF_STREAM__");
+    }
+  }
+
+  // ==================== streamBedrockResponseWithRetry - exception re-throw paths ====================
+
+  @Nested
+  @DisplayName("streamBedrockResponseWithRetry - exception paths")
+  class StreamBedrockResponseWithRetryExceptions {
+
+    @Test
+    @DisplayName("wraps IOException in ModuleException with enhanced message")
+    void ioException_wrappedInModuleException() throws Exception {
+      when(mockConnection.invokeAgent(
+                                      any(InvokeAgentRequest.class), any(InvokeAgentResponseHandler.class), anyLong()))
+          .thenAnswer(invocation -> {
+            throw new IOException("network error");
+          });
+
       try {
-        Object subscriber = getHandlerSubscriber(handler);
-        if (subscriber != null) {
-          PayloadPart chunk = PayloadPart.builder().build();
-          InvokeAgentResponseHandler.Visitor.class.getMethod("onChunk", PayloadPart.class)
-              .invoke(subscriber, chunk);
-        }
-        future.complete(null);
-      } catch (Exception e) {
-        future.completeExceptionally(e);
+        invokeStreamBedrockResponseWithRetry();
+        org.assertj.core.api.Assertions.fail("Expected ModuleException");
+      } catch (InvocationTargetException e) {
+        assertThat(e.getCause()).isInstanceOf(ModuleException.class);
+        assertThat(e.getCause().getMessage()).contains("network error");
+        assertThat(e.getCause().getCause()).isInstanceOf(IOException.class);
       }
-      return future;
-    });
+    }
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+    @Test
+    @DisplayName("wraps InterruptedException in ModuleException with enhanced message")
+    void interruptedException_wrappedInModuleException() throws Exception {
+      when(mockConnection.invokeAgent(
+                                      any(InvokeAgentRequest.class), any(InvokeAgentResponseHandler.class), anyLong()))
+          .thenAnswer(invocation -> {
+            throw new InterruptedException("interrupted");
+          });
 
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    InputStream stream = service.chatWithAgentSSEStream(
-                                                        "agentId", "aliasId", "Hi", false, false,
-                                                        sessionParams, null, null, responseParams, null);
+      try {
+        invokeStreamBedrockResponseWithRetry();
+        org.assertj.core.api.Assertions.fail("Expected ModuleException");
+      } catch (InvocationTargetException e) {
+        assertThat(e.getCause()).isInstanceOf(ModuleException.class);
+        assertThat(e.getCause().getMessage()).contains("interrupted");
+        assertThat(e.getCause().getCause()).isInstanceOf(InterruptedException.class);
+      }
+    }
 
-    assertThat(stream).isNotNull();
+    @Test
+    @DisplayName("wraps RuntimeException in ModuleException with null message handling")
+    void runtimeException_wrappedInModuleException() throws Exception {
+      when(mockConnection.invokeAgent(
+                                      any(InvokeAgentRequest.class), any(InvokeAgentResponseHandler.class), anyLong()))
+          .thenThrow(new RuntimeException());
+
+      try {
+        invokeStreamBedrockResponseWithRetry();
+        org.assertj.core.api.Assertions.fail("Expected ModuleException");
+      } catch (InvocationTargetException e) {
+        assertThat(e.getCause()).isInstanceOf(ModuleException.class);
+        assertThat(e.getCause().getCause()).isInstanceOf(RuntimeException.class);
+      }
+    }
   }
 
-  @Test
-  @DisplayName("chatWithAgent with KB config and null numberOfResults skips numberOfResults config")
-  void chatWithAgentKbConfigNullNumberOfResults() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
+  // ==================== streamBedrockResponse - sentinel retry failure ====================
 
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
+  @Nested
+  @DisplayName("streamBedrockResponse - sentinel retry failure on client disconnect")
+  class StreamBedrockResponseSentinelRetryFailure {
 
-    BedrockAgentsFilteringParameters.KnowledgeBaseConfig kbConfig =
-        new BedrockAgentsFilteringParameters.KnowledgeBaseConfig("kb-1", null,
-                                                                 BedrockAgentsFilteringParameters.SearchType.HYBRID, null, null);
-    BedrockAgentsMultipleFilteringParameters multipleParams = new BedrockAgentsMultipleFilteringParameters();
-    IntegrationTestParamHelper.setField(multipleParams, "knowledgeBases", Collections.singletonList(kbConfig));
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, multipleParams, responseParams, null);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with KB config and zero numberOfResults skips numberOfResults config")
-  void chatWithAgentKbConfigZeroNumberOfResults() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
-
-    BedrockAgentsFilteringParameters.KnowledgeBaseConfig kbConfig =
-        new BedrockAgentsFilteringParameters.KnowledgeBaseConfig("kb-1", 0,
-                                                                 BedrockAgentsFilteringParameters.SearchType.SEMANTIC, null,
-                                                                 null);
-    BedrockAgentsMultipleFilteringParameters multipleParams = new BedrockAgentsMultipleFilteringParameters();
-    IntegrationTestParamHelper.setField(multipleParams, "knowledgeBases", Collections.singletonList(kbConfig));
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, multipleParams, responseParams, null);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with KB config reranking with null selectionMode skips metadata config")
-  void chatWithAgentRerankingNullSelectionMode() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
-
-    BedrockAgentsFilteringParameters.RerankingConfiguration reranking =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    reranking.setModelArn("arn:aws:bedrock:us-east-1::foundation-model/rerank-model");
-    reranking.setSelectionMode(null);
-
-    BedrockAgentsFilteringParameters.KnowledgeBaseConfig kbConfig =
-        new BedrockAgentsFilteringParameters.KnowledgeBaseConfig("kb-1", 10, null, null, null);
-    kbConfig.setRerankingConfiguration(reranking);
-
-    BedrockAgentsMultipleFilteringParameters multipleParams = new BedrockAgentsMultipleFilteringParameters();
-    IntegrationTestParamHelper.setField(multipleParams, "knowledgeBases", Collections.singletonList(kbConfig));
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, multipleParams, responseParams, null);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with KB config reranking with ALL selectionMode")
-  void chatWithAgentRerankingAllSelectionMode() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
-
-    BedrockAgentsFilteringParameters.RerankingConfiguration reranking =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    reranking.setModelArn("arn:aws:bedrock:us-east-1::foundation-model/rerank-model");
-    reranking.setSelectionMode(BedrockAgentsFilteringParameters.RerankingSelectionMode.ALL);
-
-    BedrockAgentsFilteringParameters.KnowledgeBaseConfig kbConfig =
-        new BedrockAgentsFilteringParameters.KnowledgeBaseConfig("kb-1", 10, null, null, null);
-    kbConfig.setRerankingConfiguration(reranking);
-
-    BedrockAgentsMultipleFilteringParameters multipleParams = new BedrockAgentsMultipleFilteringParameters();
-    IntegrationTestParamHelper.setField(multipleParams, "knowledgeBases", Collections.singletonList(kbConfig));
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, multipleParams, responseParams, null);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with KB config reranking SELECTIVE with empty fieldsToExclude and fieldsToInclude")
-  void chatWithAgentRerankingSelectiveEmptyFields() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
-
-    BedrockAgentsFilteringParameters.RerankingConfiguration reranking =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    reranking.setModelArn("arn:aws:bedrock:us-east-1::foundation-model/rerank-model");
-    reranking.setSelectionMode(BedrockAgentsFilteringParameters.RerankingSelectionMode.SELECTIVE);
-    reranking.setFieldsToExclude(Collections.emptyList());
-    reranking.setFieldsToInclude(Collections.emptyList());
-
-    BedrockAgentsFilteringParameters.KnowledgeBaseConfig kbConfig =
-        new BedrockAgentsFilteringParameters.KnowledgeBaseConfig("kb-1", 10, null, null, null);
-    kbConfig.setRerankingConfiguration(reranking);
-
-    BedrockAgentsMultipleFilteringParameters multipleParams = new BedrockAgentsMultipleFilteringParameters();
-    IntegrationTestParamHelper.setField(multipleParams, "knowledgeBases", Collections.singletonList(kbConfig));
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, multipleParams, responseParams, null);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with KB config reranking null modelArn skips reranking")
-  void chatWithAgentRerankingNullModelArn() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
-
-    BedrockAgentsFilteringParameters.RerankingConfiguration reranking =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    reranking.setModelArn(null);
-
-    BedrockAgentsFilteringParameters.KnowledgeBaseConfig kbConfig =
-        new BedrockAgentsFilteringParameters.KnowledgeBaseConfig("kb-1", 10, null, null, null);
-    kbConfig.setRerankingConfiguration(reranking);
-
-    BedrockAgentsMultipleFilteringParameters multipleParams = new BedrockAgentsMultipleFilteringParameters();
-    IntegrationTestParamHelper.setField(multipleParams, "knowledgeBases", Collections.singletonList(kbConfig));
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, multipleParams, responseParams, null);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with KB config reranking empty modelArn skips reranking")
-  void chatWithAgentRerankingEmptyModelArn() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
-
-    BedrockAgentsFilteringParameters.RerankingConfiguration reranking =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    reranking.setModelArn("");
-
-    BedrockAgentsFilteringParameters.KnowledgeBaseConfig kbConfig =
-        new BedrockAgentsFilteringParameters.KnowledgeBaseConfig("kb-1", 10, null, null, null);
-    kbConfig.setRerankingConfiguration(reranking);
-
-    BedrockAgentsMultipleFilteringParameters multipleParams = new BedrockAgentsMultipleFilteringParameters();
-    IntegrationTestParamHelper.setField(multipleParams, "knowledgeBases", Collections.singletonList(kbConfig));
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, multipleParams, responseParams, null);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with retry enabled calls invokeAgent")
-  void chatWithAgentRetryEnabled() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, true, 3, 100L);
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, null, null, responseParams, null);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("chatWithAgent with metadata filters containing empty value filters them out")
-  void chatWithAgentMetadataFiltersWithEmptyValue() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
-
-    java.util.Map<String, String> filters = new java.util.HashMap<>();
-    filters.put("key1", "value1");
-    filters.put("key2", "");
-    filters.put("key3", null);
-    BedrockAgentsFilteringParameters filteringParams = new BedrockAgentsFilteringParameters();
-    IntegrationTestParamHelper.setField(filteringParams, "knowledgeBaseId", "kb-1");
-    IntegrationTestParamHelper.setField(filteringParams, "metadataFilters", filters);
-    IntegrationTestParamHelper.setField(filteringParams, "retrievalMetadataFilterType",
-                                        BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.AND_ALL);
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    String result = service.chatWithAgent(
-                                          "agentId", "aliasId", "Hi", false, false,
-                                          sessionParams, filteringParams, null, responseParams, null);
-
-    assertThat(result).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("chatWithAgentSSEStream with requestTimeout zero uses connection timeout")
-  void chatWithAgentSSEStreamTimeoutZero() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(0, TimeUnit.SECONDS, false, 2, 1000L);
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    InputStream stream = service.chatWithAgentSSEStream(
-                                                        "agentId", "aliasId", "Hi", false, false,
-                                                        sessionParams, null, null, responseParams, null);
-
-    assertThat(stream).isNotNull();
-  }
-
-  @Test
-  @DisplayName("chatWithAgentSSEStream with requestTimeout null uses connection timeout")
-  void chatWithAgentSSEStreamTimeoutNull() {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    when(connection.getConnectionTimeoutMs()).thenReturn(60_000);
-    when(connection.invokeAgent(any(), any(), anyLong())).thenReturn(CompletableFuture.completedFuture(null));
-
-    BedrockAgentsSessionParameters sessionParams = IntegrationTestParamHelper.sessionParams("s1", false, 1);
-    BedrockAgentsResponseParameters responseParams =
-        IntegrationTestParamHelper.responseParams(30, TimeUnit.SECONDS, false, 2, 1000L);
-    IntegrationTestParamHelper.setField(responseParams, "requestTimeout", null);
-
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-    InputStream stream = service.chatWithAgentSSEStream(
-                                                        "agentId", "aliasId", "Hi", false, false,
-                                                        sessionParams, null, null, responseParams, null);
-
-    assertThat(stream).isNotNull();
-  }
-
-  @Test
-  @DisplayName("buildInvokeAgentChunkJson creates JSON with text when bytes present")
-  void buildInvokeAgentChunkJsonWithBytes() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildInvokeAgentChunkJson", PayloadPart.class);
-    m.setAccessible(true);
-
-    PayloadPart chunk = PayloadPart.builder()
-        .bytes(SdkBytes.fromUtf8String("Hello chunk text"))
-        .build();
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(service, chunk);
-
-    assertThat(result.getString("type")).isEqualTo("chunk");
-    assertThat(result.getString("text")).isEqualTo("Hello chunk text");
-    assertThat(result.has("timestamp")).isTrue();
-  }
-
-  @Test
-  @DisplayName("buildInvokeAgentChunkJson creates JSON without text when bytes null")
-  void buildInvokeAgentChunkJsonWithNullBytes() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildInvokeAgentChunkJson", PayloadPart.class);
-    m.setAccessible(true);
-
-    PayloadPart chunk = PayloadPart.builder().build();
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(service, chunk);
-
-    assertThat(result.getString("type")).isEqualTo("chunk");
-    assertThat(result.has("text")).isFalse();
-  }
-
-  @Test
-  @DisplayName("buildInvokeAgentChunkJson creates JSON with citations when attribution present")
-  void buildInvokeAgentChunkJsonWithCitations() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildInvokeAgentChunkJson", PayloadPart.class);
-    m.setAccessible(true);
-
-    TextResponsePart textPart = TextResponsePart.builder().text("generated text").build();
-    GeneratedResponsePart genPart = GeneratedResponsePart.builder().textResponsePart(textPart).build();
-    RetrievalResultContent content = RetrievalResultContent.builder().text("cited content").build();
-    RetrievalResultLocation location = RetrievalResultLocation.builder().type("S3").build();
-    RetrievedReference ref = RetrievedReference.builder()
-        .content(content)
-        .location(location)
-        .metadata(Collections.singletonMap("key", Document.fromString("value")))
-        .build();
-    Citation citation = Citation.builder()
-        .generatedResponsePart(genPart)
-        .retrievedReferences(Collections.singletonList(ref))
-        .build();
-    Attribution attribution = Attribution.builder().citations(Collections.singletonList(citation)).build();
-    PayloadPart chunk = PayloadPart.builder()
-        .bytes(SdkBytes.fromUtf8String("text with citation"))
-        .attribution(attribution)
-        .build();
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(service, chunk);
-
-    assertThat(result.getString("type")).isEqualTo("chunk");
-    assertThat(result.getString("text")).isEqualTo("text with citation");
-    assertThat(result.has("citations")).isTrue();
-  }
-
-  @Test
-  @DisplayName("buildCitationJson creates JSON with generatedResponsePart and retrievedReferences")
-  void buildCitationJsonFull() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildCitationJson",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.Citation.class);
-    m.setAccessible(true);
-
-    TextResponsePart textPart = TextResponsePart.builder().text("generated text").build();
-    GeneratedResponsePart genPart = GeneratedResponsePart.builder().textResponsePart(textPart).build();
-    RetrievalResultContent content = RetrievalResultContent.builder().text("cited content").build();
-    RetrievedReference ref = RetrievedReference.builder().content(content).build();
-    Citation citation = Citation.builder()
-        .generatedResponsePart(genPart)
-        .retrievedReferences(Collections.singletonList(ref))
-        .build();
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(service, citation);
-
-    assertThat(result.getString("generatedResponsePart")).isEqualTo("generated text");
-    assertThat(result.has("retrievedReferences")).isTrue();
-  }
-
-  @Test
-  @DisplayName("buildCitationJson creates JSON without generatedResponsePart when citation has no generated part")
-  void buildCitationJsonEmpty() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildCitationJson",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.Citation.class);
-    m.setAccessible(true);
-
-    Citation citation = Citation.builder().build();
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(service, citation);
-
-    // generatedResponsePart is not set because citation.generatedResponsePart() is null or textResponsePart is null
-    assertThat(result.has("generatedResponsePart")).isFalse();
-    // retrievedReferences is set by SDK (may return empty list, not null)
-    assertThat(result.has("retrievedReferences")).isTrue();
-  }
-
-  @Test
-  @DisplayName("buildRetrievedReferenceJson creates JSON with content location and metadata")
-  void buildRetrievedReferenceJsonFull() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildRetrievedReferenceJson",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.RetrievedReference.class);
-    m.setAccessible(true);
-
-    RetrievalResultContent content = RetrievalResultContent.builder().text("ref content").build();
-    RetrievalResultLocation location = RetrievalResultLocation.builder().type("S3").build();
-    RetrievedReference ref = RetrievedReference.builder()
-        .content(content)
-        .location(location)
-        .metadata(Collections.singletonMap("key", Document.fromString("value")))
-        .build();
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(service, ref);
-
-    assertThat(result.getString("content")).isEqualTo("ref content");
-    assertThat(result.has("location")).isTrue();
-    assertThat(result.has("metadata")).isTrue();
-  }
-
-  @Test
-  @DisplayName("buildRetrievedReferenceJson creates JSON without content when ref has no content text")
-  void buildRetrievedReferenceJsonEmpty() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildRetrievedReferenceJson",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.RetrievedReference.class);
-    m.setAccessible(true);
-
-    RetrievedReference ref = RetrievedReference.builder().build();
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(service, ref);
-
-    // content is not set because ref.content() is null or content.text() is null
-    assertThat(result.has("content")).isFalse();
-    // location and metadata may be set by SDK (returns default objects, not null)
-    // Just verify JSON object is valid
-    assertThat(result).isNotNull();
-  }
-
-  @Test
-  @DisplayName("buildInvokeAgentSummary builds fullResponse from chunks with text")
-  void buildInvokeAgentSummaryWithTextChunks() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildInvokeAgentSummary",
-                                                                          java.util.List.class, long.class);
-    m.setAccessible(true);
-
-    org.json.JSONObject chunk1 = new org.json.JSONObject();
-    chunk1.put("text", "Hello ");
-    org.json.JSONObject chunk2 = new org.json.JSONObject();
-    chunk2.put("text", "World");
-    java.util.List<org.json.JSONObject> chunks = java.util.Arrays.asList(chunk1, chunk2);
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(service, chunks, System.currentTimeMillis() - 1000);
-
-    assertThat(result.getInt("totalChunks")).isEqualTo(2);
-    assertThat(result.getString("fullResponse")).isEqualTo("Hello World");
-    assertThat(result.has("total_duration_ms")).isTrue();
-  }
-
-  @Test
-  @DisplayName("createSessionStartJson creates JSON with all fields including optional ones")
-  void createSessionStartJsonFull() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("createSessionStartJson",
-                                                                          String.class, String.class, String.class, String.class,
-                                                                          String.class,
-                                                                          String.class, String.class, String.class);
-    m.setAccessible(true);
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(null, "alias1", "agent1", "Hello", "session1",
-                                                                "2026-02-05T10:00:00Z", "req123", "corr456", "user789");
-
-    assertThat(result.getString("sessionId")).isEqualTo("session1");
-    assertThat(result.getString("agentId")).isEqualTo("agent1");
-    assertThat(result.getString("agentAlias")).isEqualTo("alias1");
-    assertThat(result.getString("prompt")).isEqualTo("Hello");
-    assertThat(result.getString("processedAt")).isEqualTo("2026-02-05T10:00:00Z");
-    assertThat(result.getString("status")).isEqualTo("started");
-    assertThat(result.getString("requestId")).isEqualTo("req123");
-    assertThat(result.getString("correlationId")).isEqualTo("corr456");
-    assertThat(result.getString("userId")).isEqualTo("user789");
-  }
-
-  @Test
-  @DisplayName("createSessionStartJson creates JSON without optional fields when null or empty")
-  void createSessionStartJsonMinimal() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("createSessionStartJson",
-                                                                          String.class, String.class, String.class, String.class,
-                                                                          String.class,
-                                                                          String.class, String.class, String.class);
-    m.setAccessible(true);
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(null, "alias1", "agent1", "Hello", "session1",
-                                                                "2026-02-05T10:00:00Z", null, "", null);
-
-    assertThat(result.getString("sessionId")).isEqualTo("session1");
-    assertThat(result.has("requestId")).isFalse();
-    assertThat(result.has("correlationId")).isFalse();
-    assertThat(result.has("userId")).isFalse();
-  }
-
-  @Test
-  @DisplayName("createCompletionJson creates JSON with all fields including optional ones")
-  void createCompletionJsonFull() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("createCompletionJson",
-                                                                          String.class, String.class, String.class, long.class,
-                                                                          String.class, String.class, String.class);
-    m.setAccessible(true);
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(null, "session1", "agent1", "alias1", 1500L,
-                                                                "req123", "corr456", "user789");
-
-    assertThat(result.getString("sessionId")).isEqualTo("session1");
-    assertThat(result.getString("agentId")).isEqualTo("agent1");
-    assertThat(result.getString("agentAlias")).isEqualTo("alias1");
-    assertThat(result.getString("status")).isEqualTo("completed");
-    assertThat(result.getLong("total_duration_ms")).isEqualTo(1500L);
-    assertThat(result.getString("requestId")).isEqualTo("req123");
-    assertThat(result.getString("correlationId")).isEqualTo("corr456");
-    assertThat(result.getString("userId")).isEqualTo("user789");
-  }
-
-  @Test
-  @DisplayName("createCompletionJson creates JSON without optional fields when null or empty")
-  void createCompletionJsonMinimal() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("createCompletionJson",
-                                                                          String.class, String.class, String.class, long.class,
-                                                                          String.class, String.class, String.class);
-    m.setAccessible(true);
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(null, "session1", "agent1", "alias1", 1500L,
-                                                                null, "", null);
-
-    assertThat(result.getString("sessionId")).isEqualTo("session1");
-    assertThat(result.has("requestId")).isFalse();
-    assertThat(result.has("correlationId")).isFalse();
-    assertThat(result.has("userId")).isFalse();
-  }
-
-  @Test
-  @DisplayName("createErrorJson creates JSON with error message type and timestamp")
-  void createErrorJsonTest() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("createErrorJson", Throwable.class);
-    m.setAccessible(true);
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(null, new RuntimeException("test error message"));
-
-    assertThat(result.getString("error")).isEqualTo("test error message");
-    assertThat(result.getString("type")).isEqualTo("RuntimeException");
-    assertThat(result.has("timestamp")).isTrue();
-  }
-
-  @Test
-  @DisplayName("createChunkJson creates JSON with text and timestamp when bytes present")
-  void createChunkJsonWithBytes() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("createChunkJson", PayloadPart.class);
-    m.setAccessible(true);
-
-    PayloadPart chunk = PayloadPart.builder()
-        .bytes(SdkBytes.fromUtf8String("chunk text"))
-        .build();
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(service, chunk);
-
-    assertThat(result.getString("type")).isEqualTo("chunk");
-    assertThat(result.getString("text")).isEqualTo("chunk text");
-    assertThat(result.has("timestamp")).isTrue();
-  }
-
-  @Test
-  @DisplayName("createChunkJson creates JSON without text when bytes null")
-  void createChunkJsonWithNullBytes() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("createChunkJson", PayloadPart.class);
-    m.setAccessible(true);
-
-    PayloadPart chunk = PayloadPart.builder().build();
-
-    org.json.JSONObject result = (org.json.JSONObject) m.invoke(service, chunk);
-
-    assertThat(result.getString("type")).isEqualTo("chunk");
-    assertThat(result.has("timestamp")).isTrue();
-    assertThat(result.has("text")).isFalse();
-  }
-
-  @Test
-  @DisplayName("formatSSEEvent produces correctly formatted SSE event")
-  void formatSSEEventTest() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("formatSSEEvent", String.class, String.class);
-    m.setAccessible(true);
-
-    String result = (String) m.invoke(service, "test-event", "{\"key\":\"value\"}");
-
-    assertThat(result).contains("id:");
-    assertThat(result).contains("event: test-event");
-    assertThat(result).contains("data: {\"key\":\"value\"}");
-  }
-
-  @Test
-  @DisplayName("closeQuietly handles null stream gracefully")
-  void closeQuietlyNullStream() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("closeQuietly", java.io.PipedOutputStream.class);
-    m.setAccessible(true);
-
-    // Should not throw when passing null
-    Object result = m.invoke(service, (java.io.PipedOutputStream) null);
-    assertThat(result).isNull(); // void method returns null
-  }
-
-  @Test
-  @DisplayName("closeQuietly closes stream without throwing")
-  void closeQuietlyClosesStream() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("closeQuietly", java.io.PipedOutputStream.class);
-    m.setAccessible(true);
-
-    java.io.PipedOutputStream os = new java.io.PipedOutputStream();
-    java.io.PipedInputStream is = new java.io.PipedInputStream(os);
-
-    // Should not throw
-    Object result = m.invoke(service, os);
-    assertThat(result).isNull(); // void method returns null
-    is.close();
-  }
-
-  @Test
-  @DisplayName("buildCitationsJson creates JSONArray from citations list")
-  void buildCitationsJsonTest() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildCitationsJson", java.util.List.class);
-    m.setAccessible(true);
-
-    Citation citation1 = Citation.builder().build();
-    Citation citation2 = Citation.builder().build();
-    java.util.List<Citation> citations = java.util.Arrays.asList(citation1, citation2);
-
-    org.json.JSONArray result = (org.json.JSONArray) m.invoke(service, citations);
-
-    assertThat(result.length()).isEqualTo(2);
-  }
-
-  @Test
-  @DisplayName("buildRetrievedReferencesJson creates JSONArray from refs list")
-  void buildRetrievedReferencesJsonTest() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildRetrievedReferencesJson", java.util.List.class);
-    m.setAccessible(true);
-
-    RetrievedReference ref1 = RetrievedReference.builder().build();
-    RetrievedReference ref2 = RetrievedReference.builder().build();
-    java.util.List<RetrievedReference> refs = java.util.Arrays.asList(ref1, ref2);
-
-    org.json.JSONArray result = (org.json.JSONArray) m.invoke(service, refs);
-
-    assertThat(result.length()).isEqualTo(2);
-  }
-
-  @Test
-  @DisplayName("toDuration uses seconds when amountUnit is null")
-  void toDurationWithNullUnit() throws Exception {
-    java.lang.reflect.Method m =
-        AgentServiceImpl.class.getDeclaredMethod("toDuration", int.class, java.util.concurrent.TimeUnit.class);
-    m.setAccessible(true);
-
-    java.time.Duration result = (java.time.Duration) m.invoke(null, 30, null);
-
-    assertThat(result.getSeconds()).isEqualTo(30);
-  }
-
-  @Test
-  @DisplayName("toDuration converts using amountUnit when provided")
-  void toDurationWithUnit() throws Exception {
-    java.lang.reflect.Method m =
-        AgentServiceImpl.class.getDeclaredMethod("toDuration", int.class, java.util.concurrent.TimeUnit.class);
-    m.setAccessible(true);
-
-    java.time.Duration result = (java.time.Duration) m.invoke(null, 2, java.util.concurrent.TimeUnit.MINUTES);
-
-    assertThat(result.toMillis()).isEqualTo(120000);
-  }
-
-  @Test
-  @DisplayName("buildPromptConfigurations returns consumer that sets excludePreviousThinkingSteps and turnsToInclude")
-  void buildPromptConfigurationsTest() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m =
-        AgentServiceImpl.class.getDeclaredMethod("buildPromptConfigurations", boolean.class, Integer.class);
-    m.setAccessible(true);
-
-    Object consumer = m.invoke(service, true, 5);
-    assertThat(consumer).isNotNull();
-  }
-
-  @Test
-  @DisplayName("buildModelConfigurations returns consumer for latency optimized")
-  void buildModelConfigurationsOptimized() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildModelConfigurations", boolean.class);
-    m.setAccessible(true);
-
-    Object consumer = m.invoke(service, true);
-    assertThat(consumer).isNotNull();
-  }
-
-  @Test
-  @DisplayName("buildModelConfigurations returns consumer for standard latency")
-  void buildModelConfigurationsStandard() throws Exception {
-    BedrockConfiguration config = mock(BedrockConfiguration.class);
-    BedrockConnection connection = mock(BedrockConnection.class);
-    AgentServiceImpl service = new AgentServiceImpl(config, connection);
-
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildModelConfigurations", boolean.class);
-    m.setAccessible(true);
-
-    Object consumer = m.invoke(service, false);
-    assertThat(consumer).isNotNull();
-  }
-
-  @Test
-  @DisplayName("buildSessionState returns consumer for null kb configs")
-  void buildSessionStateNullConfigs() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildSessionState", java.util.List.class);
-    m.setAccessible(true);
-
-    Object consumer = m.invoke(null, (Object) null);
-    assertThat(consumer).isNotNull();
-  }
-
-  @Test
-  @DisplayName("buildSessionState returns consumer for empty kb configs")
-  void buildSessionStateEmptyConfigs() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildSessionState", java.util.List.class);
-    m.setAccessible(true);
-
-    Object consumer = m.invoke(null, Collections.emptyList());
-    assertThat(consumer).isNotNull();
-  }
-
-  @Test
-  @DisplayName("buildVectorSearchConfiguration returns null when no config present")
-  void buildVectorSearchConfigurationReturnsNull() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildVectorSearchConfiguration",
-                                                                          Integer.class,
-                                                                          BedrockAgentsFilteringParameters.SearchType.class,
-                                                                          BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.class,
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    Object result = m.invoke(null, null, null, null, null, null);
-    assertThat(result).isNull();
-  }
-
-  @Test
-  @DisplayName("buildVectorSearchConfiguration returns config when numberOfResults present")
-  void buildVectorSearchConfigurationWithNumberOfResults() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildVectorSearchConfiguration",
-                                                                          Integer.class,
-                                                                          BedrockAgentsFilteringParameters.SearchType.class,
-                                                                          BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.class,
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    Object result = m.invoke(null, 10, null, null, null, null);
-    assertThat(result).isNotNull();
-  }
-
-  @Test
-  @DisplayName("buildVectorSearchConfiguration returns config with search type")
-  void buildVectorSearchConfigurationWithSearchType() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildVectorSearchConfiguration",
-                                                                          Integer.class,
-                                                                          BedrockAgentsFilteringParameters.SearchType.class,
-                                                                          BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.class,
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    Object result = m.invoke(null, null, BedrockAgentsFilteringParameters.SearchType.SEMANTIC, null, null, null);
-    assertThat(result).isNotNull();
-  }
-
-  @Test
-  @DisplayName("getNonEmptyMetadataFilters returns null for null input")
-  void getNonEmptyMetadataFiltersNull() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("getNonEmptyMetadataFilters", java.util.Map.class);
-    m.setAccessible(true);
-
-    Object result = m.invoke(null, (Object) null);
-    assertThat(result).isNull();
-  }
-
-  @Test
-  @DisplayName("getNonEmptyMetadataFilters returns null for empty map")
-  void getNonEmptyMetadataFiltersEmpty() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("getNonEmptyMetadataFilters", java.util.Map.class);
-    m.setAccessible(true);
-
-    Object result = m.invoke(null, Collections.emptyMap());
-    assertThat(result).isNull();
-  }
-
-  @Test
-  @DisplayName("getNonEmptyMetadataFilters filters out null and empty values")
-  void getNonEmptyMetadataFiltersFiltersEmptyValues() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("getNonEmptyMetadataFilters", java.util.Map.class);
-    m.setAccessible(true);
-
-    java.util.Map<String, String> input = new java.util.HashMap<>();
-    input.put("key1", "value1");
-    input.put("key2", "");
-    input.put("key3", null);
-
+    @Test
+    @DisplayName("throws ModuleException when sentinel cannot be queued after drain (L1014)")
     @SuppressWarnings("unchecked")
-    java.util.Map<String, String> result = (java.util.Map<String, String>) m.invoke(null, input);
+    void sentinelRetryFailure_clientDisconnected() throws Exception {
+      when(mockConnection.invokeAgent(
+                                      any(InvokeAgentRequest.class), any(InvokeAgentResponseHandler.class), anyLong()))
+          .thenReturn(CompletableFuture.failedFuture(new RuntimeException("bedrock error")));
 
-    assertThat(result).hasSize(1);
-    assertThat(result).containsKey("key1");
+      BlockingQueue<String> mockQueue = mock(BlockingQueue.class);
+      when(mockQueue.offer(any())).thenReturn(false);
+      when(mockQueue.poll()).thenReturn("drained-event");
+      AtomicBoolean clientDisconnected = new AtomicBoolean(true);
+
+      Throwable thrown =
+          org.assertj.core.api.Assertions.catchThrowable(() -> invokeStreamBedrockResponse(mockQueue, clientDisconnected));
+      assertThat(thrown).isInstanceOf(InvocationTargetException.class);
+      assertThat(thrown.getCause())
+          .isInstanceOf(ModuleException.class)
+          .hasMessageContaining("Failed to queue end-of-stream sentinel");
+    }
   }
 
-  @Test
-  @DisplayName("buildSingleRetrievalFilter creates filter from single entry")
-  void buildSingleRetrievalFilterTest() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildSingleRetrievalFilter", java.util.Map.class);
+  // ==================== handleStreamComplete - sentinel retry failure ====================
+
+  @Nested
+  @DisplayName("handleStreamComplete - sentinel retry failure")
+  class HandleStreamCompleteSentinelRetryFailure {
+
+    @Test
+    @DisplayName("logs error when sentinel cannot be queued - client disconnected (L1129)")
+    @SuppressWarnings("unchecked")
+    void sentinelRetryFailure_clientDisconnected() throws Exception {
+      BlockingQueue<String> mockQueue = mock(BlockingQueue.class);
+      when(mockQueue.offer(any())).thenReturn(false);
+      when(mockQueue.poll()).thenReturn("drained-event");
+      AtomicBoolean clientDisconnected = new AtomicBoolean(true);
+
+      invokeHandleStreamComplete(
+                                 "session1", "agentId", "alias", System.currentTimeMillis() - 1000,
+                                 "req1", "corr1", "user1",
+                                 new AtomicInteger(5), new AtomicLong(150),
+                                 new AtomicBoolean(true), mockQueue, clientDisconnected);
+      // L1129 logger.error hit: mock queue always returns false for offer
+    }
+
+    @Test
+    @DisplayName("logs error when sentinel cannot be queued - finally block (L1162)")
+    @SuppressWarnings("unchecked")
+    void sentinelRetryFailure_finallyBlock() throws Exception {
+      BlockingQueue<String> mockQueue = mock(BlockingQueue.class);
+      when(mockQueue.offer(any())).thenReturn(false);
+      when(mockQueue.poll()).thenReturn("drained-event");
+      AtomicBoolean clientDisconnected = new AtomicBoolean(false);
+
+      invokeHandleStreamComplete(
+                                 "session1", "agentId", "alias", System.currentTimeMillis() - 1000,
+                                 "req1", "corr1", "user1",
+                                 new AtomicInteger(5), new AtomicLong(150),
+                                 new AtomicBoolean(true), mockQueue, clientDisconnected);
+      // L1162 logger.error hit: mock queue always returns false for offer in finally block
+    }
+  }
+
+  // ==================== submitToScheduler ====================
+
+  @Nested
+  @DisplayName("submitToScheduler")
+  class SubmitToScheduler {
+
+    @Test
+    @DisplayName("submits task to scheduler when capacity is available")
+    void happyPath_submitsToScheduler() throws Exception {
+      org.mule.runtime.api.scheduler.Scheduler scheduler = mock(org.mule.runtime.api.scheduler.Scheduler.class);
+      Future<?> mockFuture = mock(Future.class);
+      doAnswer(invocation -> mockFuture).when(scheduler).submit(any(Runnable.class));
+
+      Future<?> future = invokeSubmit(() -> {
+      }, scheduler);
+
+      assertThat(future).isSameAs(mockFuture);
+    }
+
+    @Test
+    @DisplayName("throws ModuleException when scheduler rejects task")
+    void rejection_throwsModuleException() {
+      org.mule.runtime.api.scheduler.Scheduler scheduler = mock(org.mule.runtime.api.scheduler.Scheduler.class);
+      when(scheduler.submit(any(Runnable.class))).thenThrow(new RejectedExecutionException("pool full"));
+
+      try {
+        invokeSubmit(() -> {
+        }, scheduler);
+        assertThat(true).as("Expected InvocationTargetException wrapping ModuleException").isFalse();
+      } catch (Exception e) {
+        assertThat(e).isInstanceOf(java.lang.reflect.InvocationTargetException.class);
+        assertThat(e.getCause()).isInstanceOf(ModuleException.class);
+        assertThat(e.getCause().getMessage()).contains("Streaming scheduler capacity exceeded");
+        assertThat(e.getCause().getCause()).isInstanceOf(RejectedExecutionException.class);
+      }
+    }
+
+    private Future<?> invokeSubmit(Runnable task,
+                                   org.mule.runtime.api.scheduler.Scheduler scheduler)
+        throws Exception {
+      Method m = AgentServiceImpl.class.getDeclaredMethod("submitToScheduler",
+                                                          Runnable.class, org.mule.runtime.api.scheduler.Scheduler.class);
+      m.setAccessible(true);
+      return (Future<?>) m.invoke(null, task, scheduler);
+    }
+  }
+
+  // ==================== Helpers ====================
+
+  private void invokeStreamBedrockResponse(BlockingQueue<String> writeQueue,
+                                           AtomicBoolean clientDisconnected)
+      throws Exception {
+    Method m = AgentServiceImpl.class.getDeclaredMethod("streamBedrockResponse",
+                                                        String.class, String.class, String.class,
+                                                        boolean.class, boolean.class,
+                                                        String.class, boolean.class, Integer.class,
+                                                        java.util.List.class,
+                                                        PipedOutputStream.class, AtomicBoolean.class,
+                                                        AtomicBoolean.class, String.class,
+                                                        String.class, String.class,
+                                                        Integer.class, TimeUnit.class,
+                                                        BlockingQueue.class, AtomicBoolean.class);
     m.setAccessible(true);
-
-    java.util.Map<String, String> filters = Collections.singletonMap("category", "tech");
-
-    Object result = m.invoke(null, filters);
-    assertThat(result).isNotNull();
+    m.invoke(service,
+             "alias", "agentId", "prompt",
+             false, false,
+             "session1", false, (Integer) null,
+             null,
+             (PipedOutputStream) null, new AtomicBoolean(false),
+             new AtomicBoolean(false), "req1",
+             "corr1", "user1",
+             (Integer) null, (TimeUnit) null,
+             writeQueue, clientDisconnected);
   }
 
-  @Test
-  @DisplayName("buildCompositeRetrievalFilter creates OR_ALL filter")
-  void buildCompositeRetrievalFilterOrAll() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildCompositeRetrievalFilter",
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.class);
+  private void invokeStreamBedrockResponseWithRetry() throws Exception {
+    StreamingRetryUtility.RetryConfig retryConfig =
+        new StreamingRetryUtility.RetryConfig(0, 1000L, true);
+
+    Method m = AgentServiceImpl.class.getDeclaredMethod("streamBedrockResponseWithRetry",
+                                                        String.class, String.class, String.class,
+                                                        boolean.class, boolean.class,
+                                                        String.class, boolean.class, Integer.class,
+                                                        java.util.List.class,
+                                                        PipedOutputStream.class, StreamingRetryUtility.RetryConfig.class,
+                                                        AtomicBoolean.class, AtomicBoolean.class,
+                                                        String.class, String.class, String.class,
+                                                        Integer.class, TimeUnit.class,
+                                                        BlockingQueue.class, AtomicBoolean.class);
     m.setAccessible(true);
-
-    java.util.Map<String, String> filters = new java.util.LinkedHashMap<>();
-    filters.put("key1", "val1");
-    filters.put("key2", "val2");
-
-    Object result = m.invoke(null, filters, BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.OR_ALL);
-    assertThat(result).isNotNull();
+    m.invoke(service,
+             "alias", "agentId", "prompt",
+             false, false,
+             "session1", false, (Integer) null,
+             null,
+             (PipedOutputStream) null, retryConfig,
+             new AtomicBoolean(false), new AtomicBoolean(false),
+             "req1", "corr1", "user1",
+             (Integer) null, (TimeUnit) null,
+             new LinkedBlockingQueue<>(), new AtomicBoolean(false));
   }
 
-  @Test
-  @DisplayName("buildCompositeRetrievalFilter creates AND_ALL filter")
-  void buildCompositeRetrievalFilterAndAll() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("buildCompositeRetrievalFilter",
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.class);
+  private void invokeHandleStreamChunk(
+                                       String agentAliasId, String agentId, String prompt, String effectiveSessionId,
+                                       String requestId, String correlationId, String userId,
+                                       AtomicBoolean chunksReceived, AtomicBoolean sessionStartSent, long startTime,
+                                       BlockingQueue<String> writeQueue, PayloadPart chunk,
+                                       AtomicInteger chunkCount, AtomicLong lastChunkTime, AtomicLong timeToFirstChunk,
+                                       AtomicBoolean clientDisconnected)
+      throws Exception {
+    Method m = AgentServiceImpl.class.getDeclaredMethod("handleStreamChunk",
+                                                        String.class, String.class, String.class, String.class,
+                                                        String.class, String.class, String.class,
+                                                        AtomicBoolean.class, AtomicBoolean.class, long.class,
+                                                        BlockingQueue.class, PayloadPart.class,
+                                                        AtomicInteger.class, AtomicLong.class, AtomicLong.class,
+                                                        AtomicBoolean.class);
     m.setAccessible(true);
-
-    java.util.Map<String, String> filters = new java.util.LinkedHashMap<>();
-    filters.put("key1", "val1");
-    filters.put("key2", "val2");
-
-    Object result = m.invoke(null, filters, BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.AND_ALL);
-    assertThat(result).isNotNull();
+    m.invoke(service, agentAliasId, agentId, prompt, effectiveSessionId,
+             requestId, correlationId, userId,
+             chunksReceived, sessionStartSent, startTime,
+             writeQueue, chunk, chunkCount, lastChunkTime, timeToFirstChunk, clientDisconnected);
   }
 
-  @Test
-  @DisplayName("convertToSdkSearchType converts HYBRID correctly")
-  void convertToSdkSearchTypeHybrid() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("convertToSdkSearchType",
-                                                                          BedrockAgentsFilteringParameters.SearchType.class);
+  private void invokeHandleStreamComplete(
+                                          String effectiveSessionId, String agentId, String agentAliasId, long startTime,
+                                          String requestId, String correlationId, String userId,
+                                          AtomicInteger chunkCount, AtomicLong timeToFirstChunk,
+                                          AtomicBoolean chunksReceived, BlockingQueue<String> writeQueue,
+                                          AtomicBoolean clientDisconnected)
+      throws Exception {
+    Method m = AgentServiceImpl.class.getDeclaredMethod("handleStreamComplete",
+                                                        String.class, String.class, String.class, long.class,
+                                                        String.class, String.class, String.class,
+                                                        AtomicInteger.class, AtomicLong.class,
+                                                        AtomicBoolean.class, BlockingQueue.class,
+                                                        AtomicBoolean.class);
     m.setAccessible(true);
-
-    Object result = m.invoke(null, BedrockAgentsFilteringParameters.SearchType.HYBRID);
-    assertThat(result).isNotNull();
-    assertThat(result.toString()).isEqualTo("HYBRID");
+    m.invoke(service, effectiveSessionId, agentId, agentAliasId, startTime,
+             requestId, correlationId, userId,
+             chunkCount, timeToFirstChunk, chunksReceived, writeQueue, clientDisconnected);
   }
 
-  @Test
-  @DisplayName("convertToSdkSearchType converts SEMANTIC correctly")
-  void convertToSdkSearchTypeSemantic() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("convertToSdkSearchType",
-                                                                          BedrockAgentsFilteringParameters.SearchType.class);
-    m.setAccessible(true);
-
-    Object result = m.invoke(null, BedrockAgentsFilteringParameters.SearchType.SEMANTIC);
-    assertThat(result).isNotNull();
-    assertThat(result.toString()).isEqualTo("SEMANTIC");
-  }
-
-  @Test
-  @DisplayName("convertToSdkSearchType returns null for null input")
-  void convertToSdkSearchTypeNull() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("convertToSdkSearchType",
-                                                                          BedrockAgentsFilteringParameters.SearchType.class);
-    m.setAccessible(true);
-
-    Object result = m.invoke(null, (Object) null);
-    assertThat(result).isNull();
-  }
-
-  @Test
-  @DisplayName("hasAnyVectorSearchConfig returns true when numberOfResults > 0")
-  void hasAnyVectorSearchConfigNumberOfResults() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("hasAnyVectorSearchConfig",
-                                                                          Integer.class,
-                                                                          BedrockAgentsFilteringParameters.SearchType.class,
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    Boolean result = (Boolean) m.invoke(null, 5, null, null, null);
-    assertThat(result).isTrue();
-  }
-
-  @Test
-  @DisplayName("hasAnyVectorSearchConfig returns false when all params null or empty")
-  void hasAnyVectorSearchConfigAllNull() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("hasAnyVectorSearchConfig",
-                                                                          Integer.class,
-                                                                          BedrockAgentsFilteringParameters.SearchType.class,
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    Boolean result = (Boolean) m.invoke(null, null, null, null, null);
-    assertThat(result).isFalse();
-  }
-
-  @Test
-  @DisplayName("hasAnyVectorSearchConfig returns true when searchType present")
-  void hasAnyVectorSearchConfigSearchType() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("hasAnyVectorSearchConfig",
-                                                                          Integer.class,
-                                                                          BedrockAgentsFilteringParameters.SearchType.class,
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    Boolean result = (Boolean) m.invoke(null, null, BedrockAgentsFilteringParameters.SearchType.HYBRID, null, null);
-    assertThat(result).isTrue();
-  }
-
-  @Test
-  @DisplayName("hasAnyVectorSearchConfig returns true when filters present")
-  void hasAnyVectorSearchConfigFilters() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("hasAnyVectorSearchConfig",
-                                                                          Integer.class,
-                                                                          BedrockAgentsFilteringParameters.SearchType.class,
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    java.util.Map<String, String> filters = Collections.singletonMap("key", "value");
-    Boolean result = (Boolean) m.invoke(null, null, null, filters, null);
-    assertThat(result).isTrue();
-  }
-
-  @Test
-  @DisplayName("hasAnyVectorSearchConfig returns true when reranking config present")
-  void hasAnyVectorSearchConfigReranking() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("hasAnyVectorSearchConfig",
-                                                                          Integer.class,
-                                                                          BedrockAgentsFilteringParameters.SearchType.class,
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    BedrockAgentsFilteringParameters.RerankingConfiguration rerankConfig =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    Boolean result = (Boolean) m.invoke(null, null, null, null, rerankConfig);
-    assertThat(result).isTrue();
-  }
-
-  @Test
-  @DisplayName("applyFilterToBuilder applies filter when filters present")
-  void applyFilterToBuilderWithFilters() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyFilterToBuilder",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-    java.util.Map<String, String> filters = Collections.singletonMap("key1", "value1");
-
-    m.invoke(null, builder, filters, BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.AND_ALL);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration config =
-        builder.build();
-    assertThat(config.filter()).isNotNull();
-  }
-
-  @Test
-  @DisplayName("applyFilterToBuilder does nothing when filters null")
-  void applyFilterToBuilderWithNullFilters() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyFilterToBuilder",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-
-    m.invoke(null, builder, null, null);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration config =
-        builder.build();
-    assertThat(config.filter()).isNull();
-  }
-
-  @Test
-  @DisplayName("applyFilterToBuilder does nothing when filters empty")
-  void applyFilterToBuilderWithEmptyFilters() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyFilterToBuilder",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          java.util.Map.class,
-                                                                          BedrockAgentsFilteringParameters.RetrievalMetadataFilterType.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-
-    m.invoke(null, builder, Collections.emptyMap(), null);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration config =
-        builder.build();
-    assertThat(config.filter()).isNull();
-  }
-
-  @Test
-  @DisplayName("applyNumberOfResults sets numberOfResults when valid")
-  void applyNumberOfResultsValid() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyNumberOfResults",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          Integer.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-
-    m.invoke(null, builder, 10);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration config =
-        builder.build();
-    assertThat(config.numberOfResults()).isEqualTo(10);
-  }
-
-  @Test
-  @DisplayName("applyNumberOfResults does nothing when null")
-  void applyNumberOfResultsNull() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyNumberOfResults",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          Integer.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-
-    m.invoke(null, builder, (Integer) null);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration config =
-        builder.build();
-    assertThat(config.numberOfResults()).isNull();
-  }
-
-  @Test
-  @DisplayName("applyNumberOfResults does nothing when zero")
-  void applyNumberOfResultsZero() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyNumberOfResults",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          Integer.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-
-    m.invoke(null, builder, 0);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration config =
-        builder.build();
-    assertThat(config.numberOfResults()).isNull();
-  }
-
-  @Test
-  @DisplayName("applyOverrideSearchType sets search type when valid")
-  void applyOverrideSearchTypeValid() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyOverrideSearchType",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          BedrockAgentsFilteringParameters.SearchType.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-
-    m.invoke(null, builder, BedrockAgentsFilteringParameters.SearchType.HYBRID);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration config =
-        builder.build();
-    assertThat(config.overrideSearchType()).isNotNull();
-    assertThat(config.overrideSearchType().toString()).isEqualTo("HYBRID");
-  }
-
-  @Test
-  @DisplayName("applyOverrideSearchType does nothing when null")
-  void applyOverrideSearchTypeNull() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyOverrideSearchType",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          BedrockAgentsFilteringParameters.SearchType.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-
-    m.invoke(null, builder, (BedrockAgentsFilteringParameters.SearchType) null);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration config =
-        builder.build();
-    assertThat(config.overrideSearchType()).isNull();
-  }
-
-  @Test
-  @DisplayName("applyRerankingConfig does nothing when config null")
-  void applyRerankingConfigNull() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyRerankingConfig",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-
-    m.invoke(null, builder, (BedrockAgentsFilteringParameters.RerankingConfiguration) null);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration config =
-        builder.build();
-    assertThat(config.rerankingConfiguration()).isNull();
-  }
-
-  @Test
-  @DisplayName("applyRerankingConfig does nothing when modelArn null")
-  void applyRerankingConfigModelArnNull() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyRerankingConfig",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-    BedrockAgentsFilteringParameters.RerankingConfiguration config =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-
-    m.invoke(null, builder, config);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration vectorConfig =
-        builder.build();
-    assertThat(vectorConfig.rerankingConfiguration()).isNull();
-  }
-
-  @Test
-  @DisplayName("applyRerankingConfig does nothing when modelArn empty")
-  void applyRerankingConfigModelArnEmpty() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyRerankingConfig",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-    BedrockAgentsFilteringParameters.RerankingConfiguration config =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    setField(config, "modelArn", "");
-
-    m.invoke(null, builder, config);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration vectorConfig =
-        builder.build();
-    assertThat(vectorConfig.rerankingConfiguration()).isNull();
-  }
-
-  @Test
-  @DisplayName("applyRerankingConfig sets config when modelArn valid")
-  void applyRerankingConfigValid() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyRerankingConfig",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-    BedrockAgentsFilteringParameters.RerankingConfiguration config =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    setField(config, "modelArn", "arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0");
-
-    m.invoke(null, builder, config);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration vectorConfig =
-        builder.build();
-    assertThat(vectorConfig.rerankingConfiguration()).isNotNull();
-  }
-
-  @Test
-  @DisplayName("applyRerankingConfig uses BEDROCK type by default")
-  void applyRerankingConfigDefaultType() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyRerankingConfig",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-    BedrockAgentsFilteringParameters.RerankingConfiguration config =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    setField(config, "modelArn", "arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0");
-
-    m.invoke(null, builder, config);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration vectorConfig =
-        builder.build();
-    assertThat(vectorConfig.rerankingConfiguration().type()).isNotNull();
-  }
-
-  @Test
-  @DisplayName("applyRerankingConfig uses custom type when provided")
-  void applyRerankingConfigCustomType() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("applyRerankingConfig",
-                                                                          software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder.class,
-                                                                          BedrockAgentsFilteringParameters.RerankingConfiguration.class);
-    m.setAccessible(true);
-
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.Builder builder =
-        software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration.builder();
-    BedrockAgentsFilteringParameters.RerankingConfiguration config =
-        new BedrockAgentsFilteringParameters.RerankingConfiguration();
-    setField(config, "modelArn", "arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0");
-    setField(config, "rerankingType", "CUSTOM_TYPE");
-
-    m.invoke(null, builder, config);
-    software.amazon.awssdk.services.bedrockagentruntime.model.KnowledgeBaseVectorSearchConfiguration vectorConfig =
-        builder.build();
-    assertThat(vectorConfig.rerankingConfiguration()).isNotNull();
-  }
-
-  @Test
-  @DisplayName("convertToSdkSearchType throws for unsupported type")
-  void convertToSdkSearchTypeUnsupported() throws Exception {
-    java.lang.reflect.Method m = AgentServiceImpl.class.getDeclaredMethod("convertToSdkSearchType",
-                                                                          BedrockAgentsFilteringParameters.SearchType.class);
-    m.setAccessible(true);
-
-    // Create a mock enum value that doesn't match HYBRID or SEMANTIC
-    // Since we can't create new enum values, we test using the default branch
-    // by relying on the existing tests for HYBRID and SEMANTIC
-    // This test verifies the method signature works
-    assertThat(m).isNotNull();
-  }
-
-  private void setField(Object obj, String fieldName, Object value) throws Exception {
-    java.lang.reflect.Field field = obj.getClass().getDeclaredField(fieldName);
-    field.setAccessible(true);
-    field.set(obj, value);
+  private static String drainQueue(BlockingQueue<String> queue) {
+    StringBuilder sb = new StringBuilder();
+    String item;
+    while ((item = queue.poll()) != null) {
+      sb.append(item);
+    }
+    return sb.toString();
   }
 }

--- a/src/test/java/com/mulesoft/connectors/bedrock/internal/util/StreamingRetryUtilityTest.java
+++ b/src/test/java/com/mulesoft/connectors/bedrock/internal/util/StreamingRetryUtilityTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
 
 @DisplayName("StreamingRetryUtility")
 class StreamingRetryUtilityTest {
@@ -148,6 +150,86 @@ class StreamingRetryUtilityTest {
       when(e.getMessage()).thenReturn(message);
       assertThat(StreamingRetryUtility.isRetryableException(e)).isTrue();
     }
+
+    @ParameterizedTest
+    @ValueSource(ints = {500, 502, 503, 504})
+    @DisplayName("returns true for SdkServiceException with 5XX status codes")
+    void sdkServiceException5xxRetryable(int statusCode) {
+      SdkServiceException e = SdkServiceException.builder()
+          .message("server error")
+          .statusCode(statusCode)
+          .build();
+      assertThat(StreamingRetryUtility.isRetryableException(e)).isTrue();
+    }
+
+    @Test
+    @DisplayName("returns true for SdkServiceException with 429 throttling")
+    void sdkServiceException429Retryable() {
+      SdkServiceException e = SdkServiceException.builder()
+          .message("Too Many Requests")
+          .statusCode(429)
+          .build();
+      assertThat(StreamingRetryUtility.isRetryableException(e)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {400, 401, 403, 404, 409, 422})
+    @DisplayName("returns false for SdkServiceException with 4XX status codes (except 429)")
+    void sdkServiceException4xxNotRetryable(int statusCode) {
+      SdkServiceException e = SdkServiceException.builder()
+          .message("client error")
+          .statusCode(statusCode)
+          .build();
+      assertThat(StreamingRetryUtility.isRetryableException(e)).isFalse();
+    }
+
+    @Test
+    @DisplayName("unwraps CompletionException with SdkServiceException 500 cause")
+    void completionExceptionWithSdkServiceException500() {
+      SdkServiceException cause = SdkServiceException.builder()
+          .message("Internal Server Error")
+          .statusCode(500)
+          .build();
+      assertThat(StreamingRetryUtility.isRetryableException(
+                                                            new CompletionException(cause)))
+          .isTrue();
+    }
+
+    @Test
+    @DisplayName("unwraps CompletionException with SdkServiceException 400 cause - not retryable")
+    void completionExceptionWithSdkServiceException400() {
+      SdkServiceException cause = SdkServiceException.builder()
+          .message("Bad Request")
+          .statusCode(400)
+          .build();
+      assertThat(StreamingRetryUtility.isRetryableException(
+                                                            new CompletionException(cause)))
+          .isFalse();
+    }
+
+    @Test
+    @DisplayName("unwraps ExecutionException with SdkServiceException 503 cause")
+    void executionExceptionWithSdkServiceException503() {
+      SdkServiceException cause = SdkServiceException.builder()
+          .message("Service Unavailable")
+          .statusCode(503)
+          .build();
+      assertThat(StreamingRetryUtility.isRetryableException(
+                                                            new ExecutionException(cause)))
+          .isTrue();
+    }
+
+    @Test
+    @DisplayName("unwraps ExecutionException with SdkServiceException 403 cause - not retryable")
+    void executionExceptionWithSdkServiceException403() {
+      SdkServiceException cause = SdkServiceException.builder()
+          .message("Access Denied")
+          .statusCode(403)
+          .build();
+      assertThat(StreamingRetryUtility.isRetryableException(
+                                                            new ExecutionException(cause)))
+          .isFalse();
+    }
   }
 
   @Nested
@@ -249,7 +331,9 @@ class StreamingRetryUtilityTest {
       StreamingRetryUtility.RetryResult result = StreamingRetryUtility.executeWithRetry(
                                                                                         () -> chunks.set(true),
                                                                                         config,
-                                                                                        chunks);
+                                                                                        chunks,
+                                                                                        "testAgent", "testSession",
+                                                                                        "testRequest");
       assertThat(result.isSuccess()).isTrue();
       assertThat(result.getAttemptsMade()).isEqualTo(1);
     }
@@ -265,7 +349,9 @@ class StreamingRetryUtilityTest {
                                                                                           throw new RuntimeException("fail");
                                                                                         },
                                                                                         config,
-                                                                                        chunks);
+                                                                                        chunks,
+                                                                                        "testAgent", "testSession",
+                                                                                        "testRequest");
       assertThat(result.isSuccess()).isFalse();
       assertThat(result.getLastException()).hasMessage("fail");
     }
@@ -281,7 +367,9 @@ class StreamingRetryUtilityTest {
                                                                                           throw new TimeoutException("timeout");
                                                                                         },
                                                                                         config,
-                                                                                        chunks);
+                                                                                        chunks,
+                                                                                        "testAgent", "testSession",
+                                                                                        "testRequest");
       assertThat(result.isSuccess()).isFalse();
       assertThat(result.isChunksReceived()).isTrue();
     }
@@ -297,7 +385,9 @@ class StreamingRetryUtilityTest {
                                                                                           throw new RuntimeException("bad request");
                                                                                         },
                                                                                         config,
-                                                                                        chunks);
+                                                                                        chunks,
+                                                                                        "testAgent", "testSession",
+                                                                                        "testRequest");
       assertThat(result.isSuccess()).isFalse();
     }
 
@@ -315,7 +405,9 @@ class StreamingRetryUtilityTest {
                                                                                           }
                                                                                         },
                                                                                         config,
-                                                                                        chunks);
+                                                                                        chunks,
+                                                                                        "testAgent", "testSession",
+                                                                                        "testRequest");
       assertThat(result.isSuccess()).isTrue();
       assertThat(result.getAttemptsMade()).isEqualTo(2);
     }
@@ -415,7 +507,9 @@ class StreamingRetryUtilityTest {
                                                                                             throw new TimeoutException("timeout");
                                                                                           },
                                                                                           config,
-                                                                                          chunks);
+                                                                                          chunks,
+                                                                                          "testAgent", "testSession",
+                                                                                          "testRequest");
         if (result.getLastException() != null
             && result.getLastException().getCause() instanceof InterruptedException) {
           interruptedResult.set(true);
@@ -470,6 +564,23 @@ class StreamingRetryUtilityTest {
   }
 
   @Nested
+  @DisplayName("isRetryableGenericException via reflection")
+  class IsRetryableGenericException {
+
+    @Test
+    @DisplayName("returns true for SdkServiceException 500 passed directly (L150)")
+    void sdkServiceException500_retryable() throws Exception {
+      SdkServiceException e = SdkServiceException.builder()
+          .message("Internal Server Error")
+          .statusCode(500)
+          .build();
+      Method m = StreamingRetryUtility.class.getDeclaredMethod("isRetryableGenericException", Exception.class);
+      m.setAccessible(true);
+      assertThat((boolean) m.invoke(null, e)).isTrue();
+    }
+  }
+
+  @Nested
   @DisplayName("executeWithRetry edge cases")
   class ExecuteWithRetryEdgeCases {
 
@@ -500,7 +611,9 @@ class StreamingRetryUtilityTest {
                                                                                           throw retryable;
                                                                                         },
                                                                                         config,
-                                                                                        chunks);
+                                                                                        chunks,
+                                                                                        "testAgent", "testSession",
+                                                                                        "testRequest");
       assertThat(result.isSuccess()).isFalse();
       assertThat(result.getAttemptsMade()).isEqualTo(3); // 1 + 2 retries
     }
@@ -522,7 +635,9 @@ class StreamingRetryUtilityTest {
                                                                                           chunks.set(true);
                                                                                         },
                                                                                         config,
-                                                                                        chunks);
+                                                                                        chunks,
+                                                                                        "testAgent", "testSession",
+                                                                                        "testRequest");
       assertThat(result.isSuccess()).isTrue();
       assertThat(result.isChunksReceived()).isTrue();
     }

--- a/src/test/munit/operations/AgentOperation-test.xml
+++ b/src/test/munit/operations/AgentOperation-test.xml
@@ -37,4 +37,490 @@
             <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
         </munit:validation>
     </munit:test>
+
+    <munit:test name="agent-chat-sse-with-multiple-kb-success">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" doc:id="7602b2fb-4b47-40aa-ae75-f98f9dac4321" variableName="agentId"/>
+            <set-variable value="KBMJXJZQWW" doc:name="Set Variable" doc:id="1a2235ed-4d27-4c86-9b57-d61d716f1006" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" doc:id="88881319-ec3e-443c-8b96-c8025e7ad462" variableName="content"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse doc:name="Agent chat streaming (SSE)" doc:id="b8eeec20-3d76-46fc-930d-8fea3ec8654f" config-ref="config-role" agentId="#[vars.agentId]" agentAliasId="#[vars.agentAlias]" prompt="#[vars.content]" sessionId="#[uuid()]">
+                <ms-bedrock:knowledge-bases >
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TH83THM0OB" numberOfResults="5" />
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5" />
+                </ms-bedrock:knowledge-bases>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="agent-chat-sse-with-single-kb-success">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" doc:id="7602b2fb-4b47-40aa-ae75-f98f9dac4321" variableName="agentId"/>
+            <set-variable value="PVU2FTSDXC" doc:name="Set Variable" doc:id="1a2235ed-4d27-4c86-9b57-d61d716f1006" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" doc:id="88881319-ec3e-443c-8b96-c8025e7ad462" variableName="content"/>
+            <set-variable value="TGJ2IEDX2Q" doc:name="Set Variable" doc:id="88881319-ec3e-443c-8b96-c8025e7ad462" variableName="KBId"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse doc:name="Agent chat streaming (SSE)" doc:id="b8eeec20-3d76-46fc-930d-8fea3ec8654f" config-ref="config-role" agentId="#[vars.agentId]" agentAliasId="#[vars.agentAlias]" prompt="#[vars.content]" sessionId="#[uuid()]" knowledgeBaseId="#[vars.KBId]" numberOfResults="5"/>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="agent-chat-sse-with-multiple-kb-retry">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" doc:id="7602b2fb-4b47-40aa-ae75-f98f9dac4321" variableName="agentId"/>
+            <set-variable value="KBMJXJZQWW" doc:name="Set Variable" doc:id="1a2235ed-4d27-4c86-9b57-d61d716f1006" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" doc:id="88881319-ec3e-443c-8b96-c8025e7ad462" variableName="content"/>
+            <!-- Record start time to validate exponential backoff duration -->
+            <set-variable variableName="startTimeMs" value="#[now() as Number {unit: 'milliseconds'}]"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse doc:name="Agent chat streaming (SSE)" doc:id="b8eeec20-3d76-46fc-930d-8fea3ec8654f" config-ref="config-role"
+                                                 agentId="#[vars.agentId]" agentAliasId="#[vars.agentAlias]"
+                                                 prompt="#[vars.content]" sessionId="#[uuid()]"
+                                                 requestTimeout="100" requestTimeoutUnit="MILLISECONDS"
+                                                 enableRetry="true" maxRetries="5" retryBackoffMs="2000">
+                <ms-bedrock:knowledge-bases >
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TH83THM0OB" numberOfResults="5" />
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5" />
+                </ms-bedrock:knowledge-bases>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <!-- Read the SSE payload once and serialize to JSON string -->
+            <set-variable variableName="ssePayload" value="#[output application/java --- write(payload, 'application/json')]"/>
+            <!-- Compute elapsed time for exponential backoff validation -->
+            <set-variable variableName="elapsedMs" value="#[now() as Number {unit: 'milliseconds'} - vars.startTimeMs]"/>
+
+            <!-- 1. Validate SSE error event is present -->
+            <munit-tools:assert-that expression="#[vars.ssePayload]"
+                                      is="#[MunitTools::notNullValue()]"
+                                      message="SSE payload should not be null"/>
+            <munit-tools:assert-that expression="#[vars.ssePayload]"
+                                      is="#[MunitTools::containsString('error')]"
+                                      message="SSE stream should contain an error event after retries exhausted"/>
+
+            <!-- 2. Validate timeout exception type -->
+            <munit-tools:assert-that expression="#[vars.ssePayload]"
+                                      is="#[MunitTools::containsString('ApiCallTimeoutException')]"
+                                      message="Error should indicate API call timeout"/>
+
+            <!-- 3. Validate retry count: 6 attempts = 1 initial + 5 retries (maxRetries=5) -->
+            <munit-tools:assert-that expression="#[vars.ssePayload]"
+                                      is="#[MunitTools::containsString('failed after 6 attempt(s) out of 6 total connector attempts')]"
+                                      message="Error should confirm all 6 attempts (1 initial + 5 retries) were made"/>
+
+            <!-- 4. Validate exponential backoff: total backoff = 2s+4s+8s+16s+32s = 62s minimum -->
+            <munit-tools:assert-that expression="#[vars.elapsedMs]"
+                                      is="#[MunitTools::greaterThanOrEqualTo(55000)]"
+                                      message="Elapsed time should be >= 55s, confirming exponential backoff (2s+4s+8s+16s+32s = 62s)"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="agent-chat-sse-with-no-retry-with-partial-chunks">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" doc:id="7602b2fb-4b47-40aa-ae75-f98f9dac4321" variableName="agentId"/>
+            <set-variable value="KBMJXJZQWW" doc:name="Set Variable" doc:id="1a2235ed-4d27-4c86-9b57-d61d716f1006" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" doc:id="88881319-ec3e-443c-8b96-c8025e7ad462" variableName="content"/>
+            <!-- Record start time to validate no-retry completes quickly -->
+            <set-variable variableName="startTimeMs" value="#[now() as Number {unit: 'milliseconds'}]"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse doc:name="Agent chat streaming (SSE)" doc:id="b8eeec20-3d76-46fc-930d-8fea3ec8654f" config-ref="config-role"
+                                                 agentId="#[vars.agentId]" agentAliasId="#[vars.agentAlias]"
+                                                 prompt="#[vars.content]" sessionId="#[uuid()]"
+                                                 requestTimeout="4000" requestTimeoutUnit="MILLISECONDS"
+                                                 enableRetry="true" maxRetries="5" retryBackoffMs="2000">
+                <ms-bedrock:knowledge-bases >
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TH83THM0OB" numberOfResults="5" />
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5" />
+                </ms-bedrock:knowledge-bases>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <!-- Read the SSE payload once and serialize to JSON string -->
+            <set-variable variableName="ssePayload" value="#[output application/java --- write(payload, 'application/json')]"/>
+            <!-- Compute elapsed time to confirm no retries occurred -->
+            <set-variable variableName="elapsedMs" value="#[now() as Number {unit: 'milliseconds'} - vars.startTimeMs]"/>
+
+            <!-- 1. Validate SSE error event is present -->
+            <munit-tools:assert-that expression="#[vars.ssePayload]"
+                                      is="#[MunitTools::notNullValue()]"
+                                      message="SSE payload should not be null"/>
+            <munit-tools:assert-that expression="#[vars.ssePayload]"
+                                      is="#[MunitTools::containsString('error')]"
+                                      message="SSE stream should contain an error event"/>
+
+            <!-- 2. Validate timeout exception with the 4000ms configured timeout -->
+            <munit-tools:assert-that expression="#[vars.ssePayload]"
+                                      is="#[MunitTools::containsString('ApiCallTimeoutException')]"
+                                      message="Error should indicate API call timeout"/>
+            <munit-tools:assert-that expression="#[vars.ssePayload]"
+                                      is="#[MunitTools::containsString('4000 millis')]"
+                                      message="Error should reference the 4000ms timeout configuration"/>
+
+            <!-- 3. Validate retry was skipped because chunks were already received -->
+            <munit-tools:assert-that expression="#[vars.ssePayload]"
+                                      is="#[MunitTools::containsString('chunks were received before failure, so retry was not attempted')]"
+                                      message="Error should confirm retry was skipped due to partial chunks already received"/>
+
+            <!-- 4. Validate no retries: elapsed time should be well under the 55s+ exponential backoff threshold -->
+            <munit-tools:assert-that expression="#[vars.elapsedMs]"
+                                      is="#[MunitTools::lessThan(50000)]"
+                                      message="Elapsed time should be under 45s, confirming no exponential backoff retries occurred (retries would take 55s+)"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="agent-chat-sse-with-override-search-hybrid-metadata">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" doc:id="7602b2fb-4b47-40aa-ae75-f98f9dac4321" variableName="agentId"/>
+            <set-variable value="KBMJXJZQWW" doc:name="Set Variable" doc:id="1a2235ed-4d27-4c86-9b57-d61d716f1006" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" doc:id="88881319-ec3e-443c-8b96-c8025e7ad462" variableName="content"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse doc:name="Agent chat streaming (SSE)" doc:id="b8eeec20-3d76-46fc-930d-8fea3ec8654f" config-ref="config-role"
+                                                 agentId="#[vars.agentId]" agentAliasId="#[vars.agentAlias]"
+                                                 prompt="#[vars.content]" sessionId="#[uuid()]" overrideSearchType="HYBRID"
+                                                 retrievalMetadataFilterType="AND_ALL">
+                <ms-bedrock:metadata-filters >
+                    <ms-bedrock:metadata-filter key="department" value="HR" />
+                    <ms-bedrock:metadata-filter key="category" value="onboarding"/>
+                </ms-bedrock:metadata-filters>
+                <ms-bedrock:knowledge-bases >
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TH83THM0OB" numberOfResults="5" />
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5" />
+                </ms-bedrock:knowledge-bases>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="agent-chat-sse-with-override-search-semantic-metadata-">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" doc:id="7602b2fb-4b47-40aa-ae75-f98f9dac4321" variableName="agentId"/>
+            <set-variable value="KBMJXJZQWW" doc:name="Set Variable" doc:id="1a2235ed-4d27-4c86-9b57-d61d716f1006" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" doc:id="88881319-ec3e-443c-8b96-c8025e7ad462" variableName="content"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse doc:name="Agent chat streaming (SSE)" doc:id="b8eeec20-3d76-46fc-930d-8fea3ec8654f" config-ref="config-role"
+                                                 agentId="#[vars.agentId]" agentAliasId="#[vars.agentAlias]"
+                                                 prompt="#[vars.content]" sessionId="#[uuid()]" overrideSearchType="SEMANTIC"
+                                                 retrievalMetadataFilterType="OR_ALL">
+                <ms-bedrock:metadata-filters >
+                    <ms-bedrock:metadata-filter key="department" value="HR" />
+                    <ms-bedrock:metadata-filter key="category" value="onboarding"/>
+                </ms-bedrock:metadata-filters>
+                <ms-bedrock:knowledge-bases >
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TH83THM0OB" numberOfResults="5" />
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5" />
+                </ms-bedrock:knowledge-bases>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
+    <!-- =================================================================== -->
+    <!-- Coverage: Legacy single-KB with SEMANTIC search + single metadata   -->
+    <!-- filter. Exercises buildSingleRetrievalFilter (L569-576),            -->
+    <!-- applyOverrideSearchType (L606-609), convertToSdkSearchType SEMANTIC -->
+    <!-- (L680), applyNumberOfResults (L601-602), getNonEmptyMetadataFilters -->
+    <!-- (L541-543). No <knowledge-bases> so legacy path is used.            -->
+    <!-- =================================================================== -->
+    <munit:test name="agent-chat-sse-legacy-kb-semantic-single-filter">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" variableName="agentId"/>
+            <set-variable value="PVU2FTSDXC" doc:name="Set Variable" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" variableName="content"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse config-ref="config-role"
+                                                 agentId="#[vars.agentId]" agentAliasId="#[vars.agentAlias]"
+                                                 prompt="#[vars.content]" sessionId="#[uuid()]"
+                                                 knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5"
+                                                 overrideSearchType="SEMANTIC">
+                <ms-bedrock:metadata-filters>
+                    <ms-bedrock:metadata-filter key="department" value="HR"/>
+                </ms-bedrock:metadata-filters>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
+    <!-- =================================================================== -->
+    <!-- Coverage: Legacy single-KB with HYBRID search + AND_ALL composite   -->
+    <!-- filter (2 metadata entries). Exercises buildCompositeRetrievalFilter -->
+    <!-- AND_ALL path (L579-592), convertToSdkSearchType HYBRID (L678).      -->
+    <!-- =================================================================== -->
+    <munit:test name="agent-chat-sse-legacy-kb-hybrid-and-all-filter">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" variableName="agentId"/>
+            <set-variable value="PVU2FTSDXC" doc:name="Set Variable" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" variableName="content"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse config-ref="config-role"
+                                                 agentId="#[vars.agentId]" agentAliasId="#[vars.agentAlias]"
+                                                 prompt="#[vars.content]" sessionId="#[uuid()]"
+                                                 knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5"
+                                                 overrideSearchType="HYBRID"
+                                                 retrievalMetadataFilterType="AND_ALL">
+                <ms-bedrock:metadata-filters>
+                    <ms-bedrock:metadata-filter key="department" value="HR"/>
+                    <ms-bedrock:metadata-filter key="category" value="onboarding"/>
+                </ms-bedrock:metadata-filters>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
+    <!-- =================================================================== -->
+    <!-- Coverage: Legacy single-KB with OR_ALL composite filter.            -->
+    <!-- Exercises buildCompositeRetrievalFilter OR_ALL else path (L594).    -->
+    <!-- =================================================================== -->
+    <munit:test name="agent-chat-sse-legacy-kb-or-all-filter">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" variableName="agentId"/>
+            <set-variable value="PVU2FTSDXC" doc:name="Set Variable" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" variableName="content"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse config-ref="config-role"
+                                                 agentId="#[vars.agentId]" agentAliasId="#[vars.agentAlias]"
+                                                 prompt="#[vars.content]" sessionId="#[uuid()]"
+                                                 knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5"
+                                                 overrideSearchType="SEMANTIC"
+                                                 retrievalMetadataFilterType="OR_ALL">
+                <ms-bedrock:metadata-filters>
+                    <ms-bedrock:metadata-filter key="department" value="HR"/>
+                    <ms-bedrock:metadata-filter key="category" value="onboarding"/>
+                </ms-bedrock:metadata-filters>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
+    <!-- =================================================================== -->
+    <!-- Coverage: KB with only ID, no vector config. Exercises              -->
+    <!-- buildVectorSearchConfiguration return null (L527), vectorCfg==null  -->
+    <!-- path in buildSessionState (L502-508).                               -->
+    <!-- =================================================================== -->
+    <munit:test name="agent-chat-sse-kb-only-id-no-vector-config">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" variableName="agentId"/>
+            <set-variable value="KBMJXJZQWW" doc:name="Set Variable" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" variableName="content"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse config-ref="config-role"
+                                                 agentId="#[vars.agentId]" agentAliasId="#[vars.agentAlias]"
+                                                 prompt="#[vars.content]" sessionId="#[uuid()]">
+                <ms-bedrock:knowledge-bases>
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TGJ2IEDX2Q"/>
+                </ms-bedrock:knowledge-bases>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
+    <!-- =================================================================== -->
+    <!-- Coverage: SSE with requestId, correlationId, userId logging params. -->
+    <!-- Exercises createCompletionJson non-null paths (L1302,1305,1308) and -->
+    <!-- createSessionStartJson non-null paths (L1356,1359,1362).            -->
+    <!-- =================================================================== -->
+    <munit:test name="agent-chat-sse-with-logging-params">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" variableName="agentId"/>
+            <set-variable value="KBMJXJZQWW" doc:name="Set Variable" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" variableName="content"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse config-ref="config-role"
+                                                 agentId="#[vars.agentId]" agentAliasId="#[vars.agentAlias]"
+                                                 prompt="#[vars.content]" sessionId="#[uuid()]"
+                                                 requestId="req-test-001"
+                                                 correlationId="corr-test-001"
+                                                 userId="user-test-001">
+                <ms-bedrock:knowledge-bases>
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5"/>
+                </ms-bedrock:knowledge-bases>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <set-variable variableName="ssePayload" value="#[output application/java --- write(payload, 'application/json')]"/>
+            <munit-tools:assert-that expression="#[vars.ssePayload]" is="#[MunitTools::notNullValue()]"/>
+            <munit-tools:assert-that expression="#[vars.ssePayload]"
+                                      is="#[MunitTools::containsString('req-test-001')]"
+                                      message="SSE stream should contain the requestId"/>
+            <munit-tools:assert-that expression="#[vars.ssePayload]"
+                                      is="#[MunitTools::containsString('corr-test-001')]"
+                                      message="SSE stream should contain the correlationId"/>
+            <munit-tools:assert-that expression="#[vars.ssePayload]"
+                                      is="#[MunitTools::containsString('user-test-001')]"
+                                      message="SSE stream should contain the userId"/>
+        </munit:validation>
+    </munit:test>
+
+    <!-- =================================================================== -->
+    <!-- Coverage: Non-streaming agent-chat with KB and requestTimeout.      -->
+    <!-- Exercises invokeAgent timeout path (L341), buildInvokeAgentRequest  -->
+    <!-- timeout override (L373-375), toDuration (L464-469).                 -->
+    <!-- =================================================================== -->
+    <munit:test name="agent-chat-with-kb-and-timeout">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" variableName="agentId"/>
+            <set-variable value="PVU2FTSDXC" doc:name="Set Variable" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" variableName="content"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat config-ref="config-role"
+                                   agentId="#[vars.agentId]" agentAliasId="#[vars.agentAlias]"
+                                   prompt="#[vars.content]" sessionId="#[uuid()]"
+                                   knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5"
+                                   overrideSearchType="SEMANTIC"
+                                   requestTimeout="30000" requestTimeoutUnit="MILLISECONDS"/>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
+    <!-- =================================================================== -->
+    <!-- Coverage: definePromptTemplate error path. Exercises                 -->
+    <!-- SdkClientException catch in definePromptTemplate (L185-186).        -->
+    <!-- =================================================================== -->
+    <munit:test name="agent-define-prompt-template-invalid-model" expectedErrorType="MULE:UNKNOWN">
+        <munit:execution>
+            <ms-bedrock:agent-define-prompt-template config-ref="config-role"
+                                                     template="Instructions: {{instructions}}. Data: {{dataset}}."
+                                                     instructions="Answer briefly."
+                                                     dataset="Sample data"
+                                                     modelName="invalid.nonexistent-model-v1:0"/>
+        </munit:execution>
+    </munit:test>
+
+    <munit:test name="agent-chat-sse-with-multiple-kb-with-reranking">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" doc:id="7602b2fb-4b47-40aa-ae75-f98f9dac4321" variableName="agentId"/>
+            <set-variable value="KBMJXJZQWW" doc:name="Set Variable" doc:id="1a2235ed-4d27-4c86-9b57-d61d716f1006" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" doc:id="88881319-ec3e-443c-8b96-c8025e7ad462" variableName="content"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse doc:name="Agent chat streaming (SSE)" doc:id="b8eeec20-3d76-46fc-930d-8fea3ec8654f"
+                                                 config-ref="config-role" agentId="#[vars.agentId]"
+                                                 agentAliasId="#[vars.agentAlias]" prompt="#[vars.content]"
+                                                 sessionId="#[uuid()]" maxRetries="5" overrideSearchType="SEMANTIC"
+                                                 retrievalMetadataFilterType="OR_ALL">
+                <ms-bedrock:metadata-filters >
+                    <ms-bedrock:metadata-filter key="department" value="HR" />
+                    <ms-bedrock:metadata-filter key="category" value="leave"/>
+                </ms-bedrock:metadata-filters>
+                <ms-bedrock:knowledge-bases >
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TH83THM0OB" numberOfResults="5" overrideSearchType="SEMANTIC" retrievalMetadataFilterType="AND_ALL">
+                        <ms-bedrock:metadata-filters >
+                            <ms-bedrock:metadata-filter key="department" value="HR" />
+                        </ms-bedrock:metadata-filters>
+                        <ms-bedrock:reranking-configuration rerankingType="BEDROCK" modelArn="arn:aws:bedrock:us-east-1::foundation-model/amazon.rerank-v1:0" numberOfRerankedResults="3" selectionMode="ALL" />
+                    </ms-bedrock:knowledge-base-config>
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5" />
+                </ms-bedrock:knowledge-bases>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="agent-chat-sse-with-multiple-kb-with-reranking-with-selective-field-exclude">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" doc:id="7602b2fb-4b47-40aa-ae75-f98f9dac4321" variableName="agentId"/>
+            <set-variable value="KBMJXJZQWW" doc:name="Set Variable" doc:id="1a2235ed-4d27-4c86-9b57-d61d716f1006" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" doc:id="88881319-ec3e-443c-8b96-c8025e7ad462" variableName="content"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse doc:name="Agent chat streaming (SSE)" doc:id="b8eeec20-3d76-46fc-930d-8fea3ec8654f"
+                                                 config-ref="config-role" agentId="#[vars.agentId]"
+                                                 agentAliasId="#[vars.agentAlias]" prompt="#[vars.content]"
+                                                 sessionId="#[uuid()]" maxRetries="5" overrideSearchType="SEMANTIC"
+                                                 retrievalMetadataFilterType="OR_ALL">
+                <ms-bedrock:metadata-filters >
+                    <ms-bedrock:metadata-filter key="department" value="HR" />
+                    <ms-bedrock:metadata-filter key="category" value="leave"/>
+                </ms-bedrock:metadata-filters>
+                <ms-bedrock:knowledge-bases >
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TH83THM0OB" numberOfResults="5" overrideSearchType="HYBRID" retrievalMetadataFilterType="OR_ALL">
+                        <ms-bedrock:metadata-filters >
+                            <ms-bedrock:metadata-filter key="department" value="HR" />
+                        </ms-bedrock:metadata-filters>
+                        <ms-bedrock:reranking-configuration rerankingType="BEDROCK" modelArn="arn:aws:bedrock:us-east-1::foundation-model/amazon.rerank-v1:0" numberOfRerankedResults="3" selectionMode="SELECTIVE">
+                        <ms-bedrock:fields-to-exclude >
+                            <ms-bedrock:fields-to-exclude-item value="maternity" />
+                        </ms-bedrock:fields-to-exclude>
+                        </ms-bedrock:reranking-configuration>
+                    </ms-bedrock:knowledge-base-config>
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5" />
+                </ms-bedrock:knowledge-bases>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="agent-chat-sse-with-multiple-kb-with-reranking-with-selective-field-include">
+        <munit:behavior>
+            <set-variable value="NCIK7YBSXH" doc:name="Set Variable" doc:id="7602b2fb-4b47-40aa-ae75-f98f9dac4321" variableName="agentId"/>
+            <set-variable value="KBMJXJZQWW" doc:name="Set Variable" doc:id="1a2235ed-4d27-4c86-9b57-d61d716f1006" variableName="agentAlias"/>
+            <set-variable value="explain HR onboarding" doc:name="Set Variable" doc:id="88881319-ec3e-443c-8b96-c8025e7ad462" variableName="content"/>
+        </munit:behavior>
+        <munit:execution>
+            <ms-bedrock:agent-chat-streaming-sse doc:name="Agent chat streaming (SSE)" doc:id="b8eeec20-3d76-46fc-930d-8fea3ec8654f"
+                                                 config-ref="config-role" agentId="#[vars.agentId]"
+                                                 agentAliasId="#[vars.agentAlias]" prompt="#[vars.content]"
+                                                 sessionId="#[uuid()]" maxRetries="5" overrideSearchType="SEMANTIC"
+                                                 retrievalMetadataFilterType="OR_ALL">
+                <ms-bedrock:metadata-filters >
+                    <ms-bedrock:metadata-filter key="department" value="HR" />
+                    <ms-bedrock:metadata-filter key="category" value="leave"/>
+                </ms-bedrock:metadata-filters>
+                <ms-bedrock:knowledge-bases >
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TH83THM0OB" numberOfResults="5" overrideSearchType="HYBRID" retrievalMetadataFilterType="OR_ALL">
+                        <ms-bedrock:metadata-filters >
+                            <ms-bedrock:metadata-filter key="department" value="HR" />
+                        </ms-bedrock:metadata-filters>
+                        <ms-bedrock:reranking-configuration rerankingType="BEDROCK" modelArn="arn:aws:bedrock:us-east-1::foundation-model/amazon.rerank-v1:0" numberOfRerankedResults="3" selectionMode="SELECTIVE">
+                            <ms-bedrock:fields-to-include >
+                                <ms-bedrock:fields-to-include-item value="maternity" />
+                            </ms-bedrock:fields-to-include>
+                            <ms-bedrock:additional-model-request-fields >
+                                <ms-bedrock:additional-model-request-field key="type" value="onboarding" />
+                            </ms-bedrock:additional-model-request-fields>
+                        </ms-bedrock:reranking-configuration>
+                    </ms-bedrock:knowledge-base-config>
+                    <ms-bedrock:knowledge-base-config knowledgeBaseId="TGJ2IEDX2Q" numberOfResults="5" />
+                </ms-bedrock:knowledge-bases>
+            </ms-bedrock:agent-chat-streaming-sse>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
 </mule>

--- a/src/test/munit/operations/BedrockOperations-test.xml
+++ b/src/test/munit/operations/BedrockOperations-test.xml
@@ -145,4 +145,14 @@
         </munit:validation>
     </munit:test>
 
+    <!-- Agent: get Agent by id -->
+    <munit:test name="get-agent-by-id">
+        <munit:execution>
+            <ms-bedrock:agent-get-by-id config-ref="config-role" agentId="NCIK7YBSXH"/>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload]" is="#[MunitTools::notNullValue()]"/>
+        </munit:validation>
+    </munit:test>
+
 </mule>

--- a/src/test/resources/automation-credentials.properties
+++ b/src/test/resources/automation-credentials.properties
@@ -1,0 +1,13 @@
+config.accessKey=
+config.secretKey=
+config.region =us-east-1
+config.security.token =
+role-config.accessKey=
+role-config.secretKey=
+role-config.roleARN=
+role-config-external.roleARN=
+role-config-external.externalId=
+role-config-external.invalidExternalId=
+
+config.agentId=
+config.agentAliasId=


### PR DESCRIPTION
* commit for thread starvation fix

* commit for thread starvation fix

* commit for thread starvation fix

* code coverage fix

* code coverage fix

* code coverage fix

* code coverage fix

* code coverage fix

* harden streaming retry logic

  - Add SdkServiceException check to retry logic: retry only on 5XX server errors and 429 throttling, never on 4XX client errors (400, 403, 404)
  - Remove JVM shutdown hook from static executor to prevent classloader leak on Mule app redeployment (daemon threads handle JVM exit)
  - Bound writeQueue to 1000 capacity to prevent OOM with slow consumers; sentinel is guaranteed delivery by draining one item if queue is full
  - Replace 500ms busy-polling loop with blocking invocationFuture.get() and whenComplete() callback for client disconnect handling
  - Reduce excessive debug logging (~30 statements removed); keep only key state transitions: thread start/stop, first chunk, errors, slow gaps

* added munits for reranking configuration

* added munits for reranking configuration

* added munits for reranking configuration

* added munits for reranking configuration

* fix sonarqube major issues

* fix sonarqube major issues

* update the config to use mule provided schedulerservice

* update the init and dispose methods synchronized

* refactored based on review comments

* refactored based on review comments

* refactored one sonar critical issue