### PR TITLE
@W-22855798: Fix new SonarQube reliability bugs in AgentServiceImpl

### DIFF
--- a/src/main/java/com/mulesoft/connectors/bedrock/internal/service/AgentServiceImpl.java
+++ b/src/main/java/com/mulesoft/connectors/bedrock/internal/service/AgentServiceImpl.java
@@ -128,7 +128,7 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
       InvokeModelResponse invokeModelResponse = getConnection().answerPrompt(invokeModelRequest);
       return PromptPayloadHelper.formatBedrockResponse(bedrockParameters, invokeModelResponse);
     } catch (SdkClientException e) {
-      throw ErrorHandler.handleSdkClientException(e, bedrockParameters.getModelName());
+      throw ErrorHandler.handleSdkClientException(e, bedrockParameters != null ? bedrockParameters.getModelName() : null);
     } finally {
       logger.info("Agent operation [AGENT-define-prompt-template] session-end durationMs={}",
                   System.currentTimeMillis() - sessionStart);
@@ -945,6 +945,10 @@ public class AgentServiceImpl extends BedrockServiceImpl implements AgentService
                                      String requestId) {
     try {
       writerFuture.get(5, TimeUnit.SECONDS);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      logger.warn("Interrupted while waiting for writer thread - agentId: {}, sessionId: {}, requestId: {}",
+                  agentId, effectiveSessionId, requestId);
     } catch (java.util.concurrent.TimeoutException te) {
       logger.warn("Writer thread did not complete within 5s - agentId: {}, sessionId: {}, requestId: {}",
                   agentId, effectiveSessionId, requestId);

--- a/src/test/java/com/mulesoft/connectors/bedrock/internal/service/AgentServiceImplTest.java
+++ b/src/test/java/com/mulesoft/connectors/bedrock/internal/service/AgentServiceImplTest.java
@@ -742,6 +742,59 @@ class AgentServiceImplTest {
     }
   }
 
+  // ==================== awaitWriterCompletion ====================
+
+  @Nested
+  @DisplayName("awaitWriterCompletion")
+  class AwaitWriterCompletion {
+
+    @Test
+    @DisplayName("returns normally when writer completes within timeout")
+    void writerCompletesNormally_returns() throws Exception {
+      Future<?> future = CompletableFuture.completedFuture(null);
+      invokeAwaitWriterCompletion(future);
+    }
+
+    @Test
+    @DisplayName("re-interrupts current thread on InterruptedException")
+    void interruptedException_reinterruptsThread() throws Exception {
+      Future<?> future = mock(Future.class);
+      when(future.get(anyLong(), any(TimeUnit.class)))
+          .thenThrow(new InterruptedException("interrupted"));
+
+      try {
+        invokeAwaitWriterCompletion(future);
+        assertThat(Thread.currentThread().isInterrupted()).isTrue();
+      } finally {
+        // Clear the interrupt so subsequent tests are not affected
+        Thread.interrupted();
+      }
+    }
+
+    @Test
+    @DisplayName("logs and continues on TimeoutException")
+    void timeoutException_logsAndReturns() throws Exception {
+      Future<?> future = mock(Future.class);
+      when(future.get(anyLong(), any(TimeUnit.class)))
+          .thenThrow(new java.util.concurrent.TimeoutException("timeout"));
+
+      invokeAwaitWriterCompletion(future);
+      // Method should return normally; thread interrupt flag should not be set
+      assertThat(Thread.currentThread().isInterrupted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("logs and continues on ExecutionException (writer thread failed)")
+    void executionException_logsAndReturns() throws Exception {
+      Future<?> future = mock(Future.class);
+      when(future.get(anyLong(), any(TimeUnit.class)))
+          .thenThrow(new java.util.concurrent.ExecutionException(new RuntimeException("boom")));
+
+      invokeAwaitWriterCompletion(future);
+      assertThat(Thread.currentThread().isInterrupted()).isFalse();
+    }
+  }
+
   // ==================== buildRetrievedReferenceJson ====================
 
   @Nested
@@ -1167,5 +1220,12 @@ class AgentServiceImplTest {
       sb.append(item);
     }
     return sb.toString();
+  }
+
+  private void invokeAwaitWriterCompletion(Future<?> writerFuture) throws Exception {
+    Method m = AgentServiceImpl.class.getDeclaredMethod("awaitWriterCompletion",
+                                                        Future.class, String.class, String.class, String.class);
+    m.setAccessible(true);
+    m.invoke(service, writerFuture, "agentId", "session1", "req1");
   }
 }


### PR DESCRIPTION
- definePromptTemplate: guard nullable bedrockParameters when building the SdkClientException error message (java:S2259, line 131).
- awaitWriterCompletion: handle InterruptedException explicitly and re-interrupt the current thread instead of swallowing the interrupt in the generic Exception branch (java:S2142, line 951).